### PR TITLE
chore: 更新 .sync-upstream-base 到 98229d8b

### DIFF
--- a/.sync-upstream-base
+++ b/.sync-upstream-base
@@ -1,1 +1,1 @@
-86bbb614d9bbcb49baf155dc50eb0ecdaba3aa4f
+98229d8b21403fb9f960aadcae5142c8aab2a98f


### PR DESCRIPTION
PR #6（Phase 19 课程 58-69 同步翻译）已合并，推进同步基准标记到对应的 upstream/main commit `98229d8b`，供下次每日同步比对使用。