### PR TITLE
feat(build): build.js 自动同步站点计数，免去手动维护

### DIFF
--- a/site/build.js
+++ b/site/build.js
@@ -451,6 +451,32 @@ const ARTIFACTS = ${JSON.stringify(artifacts, null, 2)};
 
   fs.writeFileSync(OUTPUT_PATH, output, 'utf8');
   console.log(`\n✅ Generated ${OUTPUT_PATH}`);
+
+  syncCounts(totalLessons, artifacts.length);
+}
+
+// ─── 自动同步站点文案里的课程数 / 产出数（单一真相 = 本次构建）─────
+// 每次同步新课只需在 README 表格补行 + 跑 build，站点这些散落的数字
+// 会自动对齐，不必手动逐个改（435 漂了好几个月、489 项产出过时都因此）。
+// 只处理站点模板文件，不碰 README——README 每个 phase 标题有
+// `<code>N lessons</code>` 单 phase 课数，全局替换会误伤成全局总数。
+function syncCounts(lessons, outputs) {
+  const targets = ['index.html', 'catalog.html', 'prereqs.html', 'lesson.html', 'cmdpalette.js'];
+  for (const f of targets) {
+    const p = path.join(__dirname, f);
+    if (!fs.existsSync(p)) continue;
+    const before = fs.readFileSync(p, 'utf8');
+    const after = before
+      .replace(/\d+( 节课程)/g, lessons + '$1')        // 节课程 先于 节课，避免误伤
+      .replace(/\d+ 节课(?!程)/g, lessons + ' 节课')   // 节课（后面不是「程」）
+      .replace(/\d+( 节 AI 工程)/g, lessons + '$1')
+      .replace(/\d+( lessons)\b/g, lessons + '$1')      // 英文 og/meta
+      .replace(/\d+( 项产出)/g, outputs + '$1');
+    if (after !== before) {
+      fs.writeFileSync(p, after, 'utf8');
+      console.log(`   synced counts in ${f}`);
+    }
+  }
 }
 
 build();

--- a/site/cmdpalette.js
+++ b/site/cmdpalette.js
@@ -354,7 +354,7 @@
     if (!query) {
       list.innerHTML =
         '<li class="cp-empty" role="option" aria-disabled="true">' +
-        '输入关键词，搜索 503 节课程、489 项产出以及术语表' +
+        '输入关键词，搜索 503 节课程、499 项产出以及术语表' +
         '</li>';
       _activeIdx = -1;
       return;


### PR DESCRIPTION
## 痛点（你提的「每次手动改太麻烦」）

站点 5 个文件散落着课程数/产出数文案，每次同步新课都要手动逐个改。漏改就漂：
- 课程数 **435 漂了好几个月**（少报 63 课）
- cmdpalette 的 **「489 项产出」**也一直没更新（实际 499）

## 方案

`build.js` 末尾新增 `syncCounts()`，以本次构建的真实数（`totalLessons`、`artifacts.length`）为**单一真相**，自动同步 5 个站点文件的计数文案：

```
index.html / catalog.html / prereqs.html / lesson.html / cmdpalette.js
```

覆盖中文「N 节课 / N 节课程 / N 节 AI 工程 / N 项产出」+ 英文「N lessons」全部变体。「节课程」先于「节课」替换 + 否定后顾 `(?!程)`，避免误伤。

## 刻意不碰 README

README 每个 phase 标题有 `<code>N lessons</code>` **单 phase 课数**，全局替换会误伤成全局总数。所以 README badge 仍手动维护（就一个数字，不费事）。

## 以后的流程

同步新课 → **只需在 README 表格补行 + 跑 `node site/build.js`** → 站点所有数字自动对齐。不再手动改一堆、也不会再漏（435/489 漂移的根因消除）。

## 验证
- ✅ 故意把 index.html 改「400 节课」、cmdpalette 改「100 项产出」，跑 build 后**自动改回 503 / 499**
- ✅ 「503 节课程」未被「节课」regex 误伤（否定后顾生效）
- ✅ 首跑顺手修正 cmdpalette 过时的 `489 项产出 → 499`
- ✅ 净改动仅 build.js + cmdpalette.js（data.js 时间戳已还原，PR 聚焦）