### PR TITLE
sync(zh): HuggingFace dataset canonical 路径修复（上游 #180）

### DIFF
--- a/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
+++ b/phases/00-setup-and-tooling/09-data-management/code/data_utils.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import json
 import hashlib
@@ -159,10 +158,10 @@ if __name__ == "__main__":
     print("=" * 60)
 
     print("\n--- 1. Load and inspect a dataset ---")
-    ds = load_and_inspect("rotten_tomatoes", split="train")
+    ds = load_and_inspect("cornell-movie-review-data/rotten_tomatoes", split="train")
 
     print("\n--- 2. Stream a dataset ---")
-    rows = stream_dataset("rotten_tomatoes", max_rows=3)
+    rows = stream_dataset("cornell-movie-review-data/rotten_tomatoes", max_rows=3)
     for row in rows:
         print(f"  {row['text'][:80]}...")
 

--- a/phases/00-setup-and-tooling/09-data-management/outputs/prompt-data-helper.md
+++ b/phases/00-setup-and-tooling/09-data-management/outputs/prompt-data-helper.md
@@ -33,15 +33,15 @@ Common task-to-dataset mapping:
 
 | Task | Starter Dataset | HF ID |
 |------|----------------|-------|
-| Text classification | Rotten Tomatoes | `rotten_tomatoes` |
-| Sentiment analysis | IMDB | `imdb` |
-| Natural language inference | MNLI | `glue/mnli` |
-| Question answering | SQuAD | `squad` |
-| Summarization | CNN/DailyMail | `cnn_dailymail` |
-| Translation | WMT | `wmt16` |
-| Language modeling | WikiText | `wikitext` |
-| Token classification | CoNLL-2003 | `conll2003` |
-| Image classification | MNIST / CIFAR-10 | `mnist` / `cifar10` |
+| Text classification | Rotten Tomatoes | `cornell-movie-review-data/rotten_tomatoes` |
+| Sentiment analysis | IMDB | `stanfordnlp/imdb` |
+| Natural language inference | MNLI | `nyu-mll/glue` (config:`mnli`) |
+| Question answering | SQuAD | `rajpurkar/squad` |
+| Summarization | CNN/DailyMail | `abisee/cnn_dailymail`(config: `3.0.0`) |
+| Translation | WMT | `wmt/wmt16`(config: `cs-en`) |
+| Language modeling | WikiText | `Salesforce/wikitext` |
+| Token classification | CoNLL-2003 | `lhoestq/conll2003` |
+| Image classification | MNIST / CIFAR-10 | `ylecun/mnist` / `uoft-cs/cifar10` |
 | Object detection | COCO | `detection-datasets/coco` |
 
 When recommending, prefer smaller datasets for learning and prototyping. Suggest larger datasets only when the user is ready to train at scale.


### PR DESCRIPTION
## 变更

HuggingFace 改了 dataset 命名规范，旧短 ID（如 `rotten_tomatoes`）弃用。上游 #180 更新为新 canonical 路径，本 PR 1:1 同步：

- `code/data_utils.py`：2 处路径 + 删除无用 `import os`
- `outputs/prompt-data-helper.md`：9 个 dataset 路径表格更新（`rotten_tomatoes` → `cornell-movie-review-data/rotten_tomatoes` 等。纯英文 skill 文档，无中文翻译）

## 本批上游其余改动的处理（拆分说明）

上游 `9b761233..0b2b7292` 共 8 commit，本 PR 只取独立的 HF 路径修复。其余因**绑定站点功能**或**需中文适配**，拆到后续 PR：
- 4 课 docs 加的 `figure` 交互图表块 → 依赖 `figures.js`，归入「图表功能」PR
- `figures.js` / `lesson-figures.js`（交互式图表 + KV-cache sizer）→ 图表功能 PR
- SEO 基建（sitemap/llms.txt/JSON-LD/canonical）→ 需用 `aieng-zh.cn` 域名，单独 PR
- About 页 → 需翻译 + 适配中文定位，单独 PR

## 验证
- ✅ data_utils.py 与上游 `git diff` 为空（1:1）
- ✅ prompt-data-helper.md 仅路径行变更，无其他差异