### PR TITLE
fix(site): about.html 补回主题切换脚本，修复暗色模式失效

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -169,6 +169,41 @@
   <script src="progress.js?v=20260525a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
+  <script>
+    (function () {
+      var root = document.documentElement;
+      var stored = localStorage.getItem('theme');
+      if (stored) {
+        root.setAttribute('data-theme', stored);
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        root.setAttribute('data-theme', 'dark');
+      } else {
+        root.setAttribute('data-theme', 'light');
+      }
+
+      function updateIcon() {
+        var icon = document.getElementById('themeIcon');
+        if (!icon) return;
+        icon.textContent = root.getAttribute('data-theme') === 'light' ? 'N' : 'D';
+      }
+
+      updateIcon();
+
+      document.addEventListener('DOMContentLoaded', function () {
+        updateIcon();
+
+        var btn = document.getElementById('themeToggle');
+        if (btn) {
+          btn.addEventListener('click', function () {
+            var next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+            root.setAttribute('data-theme', next);
+            localStorage.setItem('theme', next);
+            updateIcon();
+          });
+        }
+      });
+    })();
+  </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 问题
`about.html` 有主题切换按钮，但**既没引 `app.js`**（index 的 `initThemeToggle()` 在这里，是全站唯一接管 `#themeToggle` 点击的 JS），**也没有其他独立页**（`catalog`/`glossary`/`prereqs`/`lesson`）**都带的内联主题脚本**。结果按钮点了无反应，整页钉死在亮色，且不读 `localStorage.theme` / 系统 `prefers-color-scheme`。

暗色 CSS 本身正常——控制台 `document.documentElement.setAttribute("data-theme","dark")` 能让 about 页正确变暗。纯属脚本缺失的接线问题。

## 修复
补回与其他独立页一致的自包含内联主题脚本（读存储/系统偏好 → 设 `data-theme`、接管 `#themeToggle` 点击、更新 `N`/`D` 图标、持久化）。单文件、纯新增，不影响其他页。

## 验证
本地起静态服务，在 about 页操作切换按钮：

| 步骤 | data-theme | 图标 | localStorage.theme |
|------|-----------|------|--------------------|
| 初始 | `light` | N | – |
| 点击 | `dark` | D | `dark` |
| 点击 | `light` | N | `light` |

修复前点击后 `data-theme` 仍是 `light`（无 handler）；修复后正常切换并持久化，与其他页一致。

> 上游 `rohitg00/ai-engineering-from-scratch` 同样存在此问题，已同步提 issue #272 + PR #273。