### PR TITLE
feat(readme): README 重做为简体中文衍生版定位

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 <p align="center">
-  <img src="assets/banner.svg" alt="AI Engineering from Scratch — reference manual banner" width="100%">
+  <img src="assets/banner.svg" alt="AI Engineering from Scratch · 简体中文版" width="100%">
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-1a1a1a?style=flat-square&labelColor=fafaf5" alt="MIT License"></a>
+  <b>从零开始，亲手实现每一个 AI 算法</b><br/>
+  <sub>503 节课 · 20 个阶段 · Python / TypeScript / Rust / Julia · 配套中文网站 <a href="https://aieng-zh.cn">aieng-zh.cn</a></sub>
+</p>
+
+<p align="center">
+  <a href="https://aieng-zh.cn"><img src="https://img.shields.io/badge/在线阅读-aieng--zh.cn-3553ff?style=flat-square&labelColor=fafaf5" alt="在线阅读 aieng-zh.cn"></a>
   <a href="ROADMAP.md"><img src="https://img.shields.io/badge/lessons-503-3553ff?style=flat-square&labelColor=fafaf5" alt="503 lessons"></a>
   <a href="#contents"><img src="https://img.shields.io/badge/phases-20-3553ff?style=flat-square&labelColor=fafaf5" alt="20 phases"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-1a1a1a?style=flat-square&labelColor=fafaf5" alt="MIT License"></a>
   <a href="https://github.com/fancyboi999/ai-engineering-from-scratch-zh/stargazers"><img src="https://img.shields.io/github/stars/fancyboi999/ai-engineering-from-scratch-zh?style=flat-square&labelColor=fafaf5&color=3553ff" alt="GitHub stars"></a>
-  <a href="https://aieng-zh.cn"><img src="https://img.shields.io/badge/website-live-3553ff?style=flat-square&labelColor=fafaf5" alt="Website"></a>
 </p>
 
 ```
@@ -22,9 +27,24 @@
 >
 > 你不只是学 AI，你亲手把它造出来。从头到尾，全手写。
 
-> 本项目是 [AI Engineering from Scratch](https://github.com/rohitg00/ai-engineering-from-scratch) 的简体中文翻译版。感谢原作者 [Rohit Ghumare](https://github.com/rohitg00) 创作并开源了这套课程。
+> 本项目是 [AI Engineering from Scratch](https://github.com/rohitg00/ai-engineering-from-scratch)（作者 [Rohit Ghumare](https://github.com/rohitg00)，MIT 协议）的**简体中文衍生版**。衷心感谢原作者创作并开源了这套课程。
 
-## How this works
+### 这个中文版做了什么
+
+不是机器翻译堆出来的镜像。在忠实翻译之上，我们做了一套面向中文读者的本地化：
+
+| | |
+|---|---|
+| 🇨🇳 **全站简体中文** | 503 节课正文、83 条术语表、测验题、`mermaid` 流程图、交互图表标签全部中文化（`agent`、`token`、`transformer` 等技术术语按惯例保留英文） |
+| 🌐 **独立中文网站 [aieng-zh.cn](https://aieng-zh.cn)** | 可搜索的课程目录、学习进度追踪、可拖动的交互式图表、命令面板（`Cmd / Ctrl + K`）、深色模式 |
+| 🔍 **为 AI 检索优化** | 构建时自动生成 `sitemap.xml` / `llms.txt` / 结构化数据，方便被搜索引擎和 AI 助手引用 |
+| ✅ **课数一致性护栏** | CI 自动校验课程数（`node site/build.js --check`），防止课程列表与磁盘上的实际内容漂移 |
+
+> 翻译怎么翻见 [TRANSLATION.md](TRANSLATION.md)。课程结构、代码与上游保持一致，译文持续跟进上游更新。
+
+**目录** · [怎么运作](#怎么运作) · [课程结构](#课程的结构) · [一节课的样子](#一节课的样子) · [快速开始](#快速开始) · [每节课都有产出](#每节课都有产出) · [课程目录](#contents) · [工具箱](#工具箱) · [参与贡献](#参与贡献)
+
+## 怎么运作
 
 大多数 AI 教材都是碎片化教学。这儿一篇论文，那儿一篇微调心得，别处再来个炫酷的 agent
 demo。这些碎片很少能拼到一起。你做出了一个聊天机器人，却讲不清它的 loss 曲线；你给
@@ -41,7 +61,7 @@ agent 挂了个函数，却说不出调用它的那个模型内部，attention �
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
 ```
 
-## The shape of the curriculum
+## 课程的结构
 
 二十个阶段层层叠起来。数学是地基，agent 和生产部署是屋顶。下层的东西你已经会了，就尽管
 往前跳；但别跳过去之后，又回头纳闷上层为什么塌了。
@@ -76,7 +96,7 @@ flowchart TB
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
 ```
 
-## The shape of a lesson
+## 一节课的样子
 
 每节课都待在自己的文件夹里，整套课程结构统一：
 
@@ -102,7 +122,7 @@ flowchart LR
   U --> S["SHIP IT<br/><sub>prompt · skill · agent · MCP</sub>"]
 ```
 
-## Getting started
+## 快速开始
 
 三种入门方式。挑一个。
 
@@ -149,7 +169,7 @@ ls phases/03-deep-learning-core/05-loss-functions/outputs/
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒
 ```
 
-## Every lesson ships something
+## 每节课都有产出
 
 别的课程结尾是一句 *"恭喜，你学会了 X。"* 这里每节课的结尾，是一件你能直接装上、
 或粘进日常工作流的 **可复用工具**。
@@ -170,7 +190,7 @@ ls phases/03-deep-learning-core/05-loss-functions/outputs/
 </table>
 
 > 用 `python3 scripts/install_skills.py` 一次性全部安装。是真家伙，不是课后作业。
-> 学完整套课程，你会攒下 435 件作品——你是真懂它们，因为它们都是你亲手造的。
+> 学完整套课程，你会攒下近 500 件产物——你是真懂它们，因为它们都是你亲手造的。
 
 ### FIG_002 · 一个实例
 
@@ -230,7 +250,7 @@ the agent went wrong and explain why...
 
 <a id="contents"></a>
 
-## Contents
+## 课程目录
 
 二十个阶段。点开任意阶段即可展开它的课程列表。
 
@@ -936,7 +956,7 @@ outputs/
 
 ### 把所有课程技能装进你的 agent
 
-仓库在 `phases/**/outputs/` 下交付了 378 个技能和 99 个提示词。
+仓库在 `phases/**/outputs/` 下交付了 388 个技能和 99 个提示词。
 
 **推荐：通过 [skills.sh](https://skills.sh) 安装。** 不用 clone，不用 Python，
 自动识别你 agent 的技能目录：
@@ -973,7 +993,7 @@ python3 scripts/install_skills.py <target> --force                         # 覆
 用 `--dry-run` 预览冲突，或用 `--force` 覆盖。每次非 dry-run 的运行都会在目标里
 写一份 `manifest.json`，按类型和阶段分组列出完整清单。挑你 agent 读取的那种布局：
 
-| `--layout`  | Path written |
+| `--layout`  | 写入路径 |
 |---|---|
 | `skills`    | `<target>/<name>/SKILL.md`（嵌套约定，Claude / Cursor / Codex / OpenClaw / Hermes 都支持） |
 | `by-phase`  | `<target>/phase-NN/<name>.md` |
@@ -1040,13 +1060,13 @@ python3 scripts/lesson_run.py --execute        # 真正运行，每节课 10 秒
 
 ## 从哪里开始
 
-| Background | Start at | Estimated time |
+| 你的背景 | 从哪开始 | 预计时间 |
 |---|---|---|
-| 编程和 AI 都是新手 | Phase 0 — 配置 | ~306 hours |
-| 会 Python，刚接触 ML | Phase 1 — 数学基础 | ~270 hours |
-| 懂 ML，刚接触深度学习 | Phase 3 — 深度学习核心 | ~200 hours |
-| 懂深度学习，想学 LLM 和 agent | Phase 10 — 从零实现 LLM | ~100 hours |
-| 资深工程师，只想要 agent 工程 | Phase 14 — Agent 工程 | ~60 hours |
+| 编程和 AI 都是新手 | 阶段 0 — 配置与工具链 | ~306 小时 |
+| 会 Python，刚接触 ML | 阶段 1 — 数学基础 | ~270 小时 |
+| 懂 ML，刚接触深度学习 | 阶段 3 — 深度学习核心 | ~200 小时 |
+| 懂深度学习，想学 LLM 和 agent | 阶段 10 — 从零实现 LLM | ~100 小时 |
+| 资深工程师，只想要 agent 工程 | 阶段 14 — Agent 工程 | ~60 小时 |
 
 ```
 ░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒░░░▒▒▒

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="ROADMAP.md"><img src="https://img.shields.io/badge/lessons-503-3553ff?style=flat-square&labelColor=fafaf5" alt="503 lessons"></a>
   <a href="#contents"><img src="https://img.shields.io/badge/phases-20-3553ff?style=flat-square&labelColor=fafaf5" alt="20 phases"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-1a1a1a?style=flat-square&labelColor=fafaf5" alt="MIT License"></a>
-  <a href="https://github.com/fancyboi999/ai-engineering-from-scratch-zh/stargazers"><img src="https://img.shields.io/github/stars/fancyboi999/ai-engineering-from-scratch-zh?style=flat-square&labelColor=fafaf5&color=3553ff" alt="GitHub stars"></a>
+  <a href="https://github.com/fancyboi999/ai-engineering-from-scratch-zh/stargazers"><img src="https://img.shields.io/github/stars/fancyboi999/ai-engineering-from-scratch-zh?style=flat-square&labelColor=fafaf5&color=3553ff&cacheSeconds=21600" alt="GitHub stars"></a>
 </p>
 
 ```
@@ -69,25 +69,25 @@ agent 挂了个函数，却说不出调用它的那个模型内部，attention �
 ```mermaid
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#fafaf5','primaryTextColor':'#1a1a1a','primaryBorderColor':'#3553ff','lineColor':'#3553ff','fontFamily':'JetBrains Mono','fontSize':'12px'}}}%%
 flowchart TB
-  P0["Phase 0 — Setup &amp; Tooling"] --> P1["Phase 1 — Math Foundations"]
-  P1 --> P2["Phase 2 — ML Fundamentals"]
-  P2 --> P3["Phase 3 — Deep Learning Core"]
-  P3 --> P4["Phase 4 — Vision"]
-  P3 --> P5["Phase 5 — NLP"]
-  P3 --> P6["Phase 6 — Speech &amp; Audio"]
-  P3 --> P9["Phase 9 — RL"]
-  P5 --> P7["Phase 7 — Transformers"]
-  P7 --> P8["Phase 8 — GenAI"]
-  P7 --> P10["Phase 10 — LLMs from Scratch"]
-  P10 --> P11["Phase 11 — LLM Engineering"]
-  P10 --> P12["Phase 12 — Multimodal"]
-  P11 --> P13["Phase 13 — Tools &amp; Protocols"]
-  P13 --> P14["Phase 14 — Agent Engineering"]
-  P14 --> P15["Phase 15 — Autonomous Systems"]
-  P15 --> P16["Phase 16 — Multi-Agent &amp; Swarms"]
-  P14 --> P17["Phase 17 — Infrastructure &amp; Production"]
-  P15 --> P18["Phase 18 — Ethics &amp; Alignment"]
-  P16 --> P19["Phase 19 — Capstone Projects"]
+  P0["阶段 0 · 配置与工具链"] --> P1["阶段 1 · 数学基础"]
+  P1 --> P2["阶段 2 · 机器学习基础"]
+  P2 --> P3["阶段 3 · 深度学习核心"]
+  P3 --> P4["阶段 4 · 计算机视觉"]
+  P3 --> P5["阶段 5 · NLP"]
+  P3 --> P6["阶段 6 · 语音与音频"]
+  P3 --> P9["阶段 9 · 强化学习"]
+  P5 --> P7["阶段 7 · Transformer"]
+  P7 --> P8["阶段 8 · 生成式 AI"]
+  P7 --> P10["阶段 10 · 从零实现 LLM"]
+  P10 --> P11["阶段 11 · LLM 工程"]
+  P10 --> P12["阶段 12 · 多模态 AI"]
+  P11 --> P13["阶段 13 · 工具与协议"]
+  P13 --> P14["阶段 14 · Agent 工程"]
+  P14 --> P15["阶段 15 · 自主系统"]
+  P15 --> P16["阶段 16 · 多 agent 与集群"]
+  P14 --> P17["阶段 17 · 基础设施与生产"]
+  P15 --> P18["阶段 18 · 伦理、安全与对齐"]
+  P16 --> P19["阶段 19 · 综合项目"]
   P17 --> P19
   P18 --> P19
 ```
@@ -115,11 +115,11 @@ phases/<NN>-<phase-name>/<NN>-<lesson-name>/
 ```mermaid
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#fafaf5','primaryTextColor':'#1a1a1a','primaryBorderColor':'#3553ff','lineColor':'#3553ff','fontFamily':'JetBrains Mono','fontSize':'13px'}}}%%
 flowchart LR
-  M["MOTTO<br/><sub>one-line core idea</sub>"] --> Pr["PROBLEM<br/><sub>concrete pain</sub>"]
-  Pr --> C["CONCEPT<br/><sub>diagrams &amp; intuition</sub>"]
-  C --> B["BUILD IT<br/><sub>raw math, no frameworks</sub>"]
-  B --> U["USE IT<br/><sub>same thing in PyTorch / sklearn</sub>"]
-  U --> S["SHIP IT<br/><sub>prompt · skill · agent · MCP</sub>"]
+  M["主旨<br/><sub>一句话核心理念</sub>"] --> Pr["问题背景<br/><sub>具体的痛点</sub>"]
+  Pr --> C["核心概念<br/><sub>图解与直觉</sub>"]
+  C --> B["动手构建<br/><sub>纯数学，不用框架</sub>"]
+  B --> U["实际使用<br/><sub>同样的事用 PyTorch / sklearn 跑一遍</sub>"]
+  U --> S["拿去用<br/><sub>提示词 · 技能 · agent · MCP</sub>"]
 ```
 
 ## 快速开始

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ agent 挂了个函数，却说不出调用它的那个模型内部，attention �
 往前跳；但别跳过去之后，又回头纳闷上层为什么塌了。
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#fafaf5','primaryTextColor':'#1a1a1a','primaryBorderColor':'#3553ff','lineColor':'#3553ff','fontFamily':'JetBrains Mono','fontSize':'12px'}}}%%
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#fafaf5','primaryTextColor':'#1a1a1a','primaryBorderColor':'#3553ff','lineColor':'#3553ff'}}}%%
 flowchart TB
   P0["阶段 0 · 配置与工具链"] --> P1["阶段 1 · 数学基础"]
   P1 --> P2["阶段 2 · 机器学习基础"]
@@ -113,7 +113,7 @@ phases/<NN>-<phase-name>/<NN>-<lesson-name>/
 版本你自己写过。
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#fafaf5','primaryTextColor':'#1a1a1a','primaryBorderColor':'#3553ff','lineColor':'#3553ff','fontFamily':'JetBrains Mono','fontSize':'13px'}}}%%
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#fafaf5','primaryTextColor':'#1a1a1a','primaryBorderColor':'#3553ff','lineColor':'#3553ff'}}}%%
 flowchart LR
   M["主旨<br/><sub>一句话核心理念</sub>"] --> Pr["问题背景<br/><sub>具体的痛点</sub>"]
   Pr --> C["核心概念<br/><sub>图解与直觉</sub>"]

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ phases/<NN>-<phase-name>/<NN>-<lesson-name>/
 ```mermaid
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#fafaf5','primaryTextColor':'#1a1a1a','primaryBorderColor':'#3553ff','lineColor':'#3553ff'}}}%%
 flowchart LR
-  M["主旨<br/><sub>一句话核心理念</sub>"] --> Pr["问题背景<br/><sub>具体的痛点</sub>"]
-  Pr --> C["核心概念<br/><sub>图解与直觉</sub>"]
-  C --> B["动手构建<br/><sub>纯数学，不用框架</sub>"]
-  B --> U["实际使用<br/><sub>同样的事用 PyTorch / sklearn 跑一遍</sub>"]
-  U --> S["拿去用<br/><sub>提示词 · 技能 · agent · MCP</sub>"]
+  M["主旨<br/>一句话核心理念"] --> Pr["问题背景<br/>具体的痛点"]
+  Pr --> C["核心概念<br/>图解与直觉"]
+  C --> B["动手构建<br/>纯数学，不用框架"]
+  B --> U["实际使用<br/>同样的事用 PyTorch / sklearn 跑一遍"]
+  U --> S["拿去用<br/>提示词 · 技能 · agent · MCP"]
 ```
 
 ## 快速开始


### PR DESCRIPTION
## 改动

把中文仓 README 从「翻译版」升级为「简体中文衍生版」定位，差异化呈现本地化价值：

- banner/slogan 中文化 + 新增「在线阅读 aieng-zh.cn」badge，badge 顺序整理
- 新增「这个中文版做了什么」特性表（全站中文 / 独立网站 / 为 AI 检索优化 / 课数护栏）
- 新增目录导航行 + 6 处章节标题中文化（How this works→怎么运作 等）
- 表格表头中文化（写入路径、你的背景·从哪开始·预计时间、hours→小时）
- 修正过时数字：作品 435→近 500、技能 378→388

## 验证

- 数字按 `site/build.js` 口径核准：503 课、388 技能（`skill-*.md`）、99 提示词（`prompt-*.md`）、outputs 493 均属实
- `TRANSLATION.md` 存在、8 个目录锚点全部命中、4 语言（py595·ts129·rs10·jl20）说法属实
- 纯 README 文档改动，不涉及课程内容 / 站点代码
