### PR TITLE
fix(site): 修复课程页 mermaid 图中文文字截断

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -1640,7 +1640,7 @@
     mermaid.initialize({
       startOnLoad: false,
       theme: document.documentElement.getAttribute('data-theme') === 'light' ? 'default' : 'dark',
-      fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+      fontFamily: '"JetBrains Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", sans-serif',
       themeVariables: {
         fontSize: '13px'
       },
@@ -2622,7 +2622,7 @@
           window._mermaidReady.initialize({
             startOnLoad: false,
             theme: mermaidTheme(),
-            fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+            fontFamily: '"JetBrains Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", sans-serif',
             themeVariables: { fontSize: '13px' },
             flowchart: { useMaxWidth: true, htmlLabels: true, nodeSpacing: 40, rankSpacing: 50, padding: 12 }
           });

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2649,8 +2649,12 @@
       function fixMermaidClusterLabels(root) {
         if (!root) return;
         root.querySelectorAll('.cluster foreignObject').forEach(function (fo) {
-          var div = fo.firstElementChild || fo;
-          var need = Math.ceil(Math.max(div.scrollWidth, div.getBoundingClientRect().width)) + 8;
+          fo.style.overflow = 'visible'; // 兜底：万一加宽仍差几 px，也让末字显示而非裁掉
+          var need = 0; // 测真实文字宽：div 是 display:table-cell，须遍历到内层 p/span 才准
+          fo.querySelectorAll('*').forEach(function (el) {
+            need = Math.max(need, el.scrollWidth, el.getBoundingClientRect().width);
+          });
+          need = Math.ceil(need) + 6;
           var cur = parseFloat(fo.getAttribute('width')) || 0;
           if (need > cur) {
             var x = parseFloat(fo.getAttribute('x')) || 0;
@@ -2678,7 +2682,7 @@
           window._mermaidReady.render('mermaid-' + idx + '-svg', def).then(function (result) {
             if (target._mermaidRenderToken !== token) return;
             target.innerHTML = result.svg;
-            requestAnimationFrame(function () { fixMermaidClusterLabels(target); });
+            (document.fonts ? document.fonts.ready : Promise.resolve()).then(function () { requestAnimationFrame(function () { fixMermaidClusterLabels(target); }); });
           }).catch(function () {
             if (target._mermaidRenderToken !== token) return;
             target.innerHTML = '<p style="color:var(--text-muted);font-style:italic;">图表无法渲染。</p>';
@@ -2791,7 +2795,7 @@
         window._mermaidReady.render('mermaid-modal-svg', def).then(function (result) {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = result.svg;
-          requestAnimationFrame(function () { fixMermaidClusterLabels(center); });
+          (document.fonts ? document.fonts.ready : Promise.resolve()).then(function () { requestAnimationFrame(function () { fixMermaidClusterLabels(center); }); });
         }).catch(function () {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = '<p style="color:var(--text-muted);font-style:italic;">图表无法渲染。</p>';

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -924,16 +924,28 @@
       .mermaid-modal-body foreignObject p,
       .mermaid-modal-body foreignObject span
     ) {
-      font-family: var(--font-mono);
+      font-family: "JetBrains Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", sans-serif;
       font-size: 13px;
-      line-height: 1.4;
-      letter-spacing: 0.02em;
+      line-height: 1.5;
+      letter-spacing: normal;
       text-align: center;
       text-transform: none;
       margin: 0;
       hyphens: none;
       -webkit-hyphens: none;
       color: var(--ink);
+    }
+
+    /* 课程图里所有 SVG text（subgraph 标题 / stateDiagram note / 连线标签）
+       与 htmlLabels 用同一中文字体栈，保证宽度测量=显示一致，中文不再走丑的
+       系统等宽 fallback，也避免 CJK 测量偏差导致的截断。 */
+    .lesson-article .mermaid-render svg text,
+    .lesson-article .mermaid-render svg .nodeLabel,
+    .lesson-article .mermaid-render svg .edgeLabel,
+    .mermaid-modal-body svg text,
+    .mermaid-modal-body svg .nodeLabel,
+    .mermaid-modal-body svg .edgeLabel {
+      font-family: "JetBrains Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", sans-serif;
     }
 
     .lesson-nav-bottom {
@@ -2631,6 +2643,23 @@
         rerenderMermaidModal();
       }
 
+      // mermaid subgraph 标题（cluster label）中文截断 workaround：上游已知 bug——
+      // 测量标题宽度用 SVG、渲染用 HTML，二者对中文宽度对不上，foreignObject(overflow hidden)
+      // 把超出的末字裁掉。渲染后把每个 cluster 标题的 foreignObject 加宽到容纳文字 + 居中。
+      function fixMermaidClusterLabels(root) {
+        if (!root) return;
+        root.querySelectorAll('.cluster foreignObject').forEach(function (fo) {
+          var div = fo.firstElementChild || fo;
+          var need = Math.ceil(Math.max(div.scrollWidth, div.getBoundingClientRect().width)) + 8;
+          var cur = parseFloat(fo.getAttribute('width')) || 0;
+          if (need > cur) {
+            var x = parseFloat(fo.getAttribute('x')) || 0;
+            fo.setAttribute('width', need);
+            fo.setAttribute('x', x - (need - cur) / 2);
+          }
+        });
+      }
+
       function rerenderMermaidBlocks() {
         if (!window._mermaidReady) return;
         var sources = document.querySelectorAll('pre.mermaid.mermaid-source');
@@ -2649,6 +2678,7 @@
           window._mermaidReady.render('mermaid-' + idx + '-svg', def).then(function (result) {
             if (target._mermaidRenderToken !== token) return;
             target.innerHTML = result.svg;
+            requestAnimationFrame(function () { fixMermaidClusterLabels(target); });
           }).catch(function () {
             if (target._mermaidRenderToken !== token) return;
             target.innerHTML = '<p style="color:var(--text-muted);font-style:italic;">图表无法渲染。</p>';
@@ -2761,6 +2791,7 @@
         window._mermaidReady.render('mermaid-modal-svg', def).then(function (result) {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = result.svg;
+          requestAnimationFrame(function () { fixMermaidClusterLabels(center); });
         }).catch(function () {
           if (center._mermaidRenderToken !== token) return;
           center.innerHTML = '<p style="color:var(--text-muted);font-style:italic;">图表无法渲染。</p>';

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2648,8 +2648,13 @@
       // 把超出的末字裁掉。渲染后把每个 cluster 标题的 foreignObject 加宽到容纳文字 + 居中。
       function fixMermaidClusterLabels(root) {
         if (!root) return;
+        // 非节点的 foreignObject（cluster 标题 / edge label 连线标签 / note）overflow 兜底：
+        // 中文测量偏窄导致框算小时，让超出文字显示而非被裁。节点不动（字体修复已够，且加宽会破坏布局）。
+        root.querySelectorAll('foreignObject').forEach(function (fo) {
+          if (!fo.closest('.node')) fo.style.overflow = 'visible';
+        });
+        // cluster 标题额外加宽 + 居中（让背景框也容纳，比单纯溢出更美观）
         root.querySelectorAll('.cluster foreignObject').forEach(function (fo) {
-          fo.style.overflow = 'visible'; // 兜底：万一加宽仍差几 px，也让末字显示而非裁掉
           var need = 0; // 测真实文字宽：div 是 display:table-cell，须遍历到内层 p/span 才准
           fo.querySelectorAll('*').forEach(function (el) {
             need = Math.max(need, el.scrollWidth, el.getBoundingClientRect().width);


### PR DESCRIPTION
## 问题

课程页（lesson.html）的 mermaid 图大量中文被裁切：subgraph 标题末字（「应用协议」→「应用协」）、节点文字溢出框、连线/标签截断。涉及面广。

## 根因（headless 实测定位）

1. **节点/普通标签**：`mermaid.initialize` 的 `fontFamily: 'JetBrains Mono'` 无中文字形，mermaid 测量文字宽度时按它算 → 中文偏窄 → 框算小 → 渲染时实际更宽 → 溢出被裁。
2. **subgraph 标题（cluster label）**：mermaid 上游已知 bug（[#814](https://github.com/mermaid-js/mermaid/issues/814) 等）——测量走 SVG、渲染走 HTML，中文宽度天生对不上，**改字体也救不了**（headless 实测框宽不随字体变）。

## 修复

1. 两处 `mermaid.initialize` 的 `fontFamily` 加中文 fallback（PingFang SC / Microsoft YaHei / Noto Sans SC）→ 修节点测量。
2. 新增 `fixMermaidClusterLabels()`，每次渲染后（主渲染 + 放大框）：
   - 非节点 foreignObject（cluster 标题 / edge label / note）`overflow:visible` 兜底，超出显示而非裁掉；
   - cluster 标题额外加宽 + 居中（`document.fonts.ready` 后测量，遍历内层 p/span 取真实宽度）。

## 验证（puppeteer 加载真实页面）

- **全量扫 194 个含 mermaid 的课**：初版残留 33 课 → 加固后仅 1 处 edge label → 兜底扩展后 **0 真残留**。
- **before/after 截图**确认 communication-protocols（三层协议 subgraph 标题）、inference-optimization（PagedAttention/连续分配）、function-call-dispatcher（连线标签）全部文字完整。
- 纯 `site/lesson.html` 改动，不碰课程内容。
