### PR TITLE
feat(site): 课程正文数学公式 KaTeX 渲染

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2495,14 +2495,17 @@
       function looksLikeMath(s) {
         if (/[一-鿿]/.test(s)) return false;
         if (s.indexOf('&quot;') !== -1 || s.indexOf('$') !== -1) return false;
+        // 字面 &lt; 只可能来自 em/strong 注入残留（真实 < 已是 &amp;lt;），整 span 拒绝
+        if (s.indexOf('&lt;') !== -1) return false;
         // 单引号：开引号（前面不是标识符/右括号）按字符串字面量排除；prime 记法如 V(s') 放行
         if (/(^|[^a-zA-Z0-9)\]])&#39;/.test(s)) return false;
         if (s.indexOf('*') !== -1) return false;
         if (/_[a-z]{4,}/.test(s)) return false;
         if (/--|::|=&gt;|-&gt;|\/\//.test(s)) return false;
+        // ^ 上标要求前面有底数字符（拒正则锚点如 ^Bearer）；| 别漏，双范数 ||q||^2 靠它
         return /[_^]\{/.test(s) ||
           /[½⅓¼·≈≠≤≥±×÷√∇∂∑Σ∏∫πθμσεαβγλδηρτφψωΩΔ∈∉∞∝∀∃²³ᵀ]/.test(s) ||
-          /\^[0-9a-zA-Z(]/.test(s);
+          /[0-9a-zA-Z)\]}|]\^[0-9a-zA-Z(]/.test(s);
       }
 
       function inlineFormat(text) {
@@ -2535,7 +2538,8 @@
         s = s.replace(/([A-Za-zα-ωΑ-Ω])̂/g, '\\hat{$1}');
         s = s.replace(/ŵ/g, '\\hat{w}').replace(/â/g, '\\hat{a}');
         s = s.replace(/√/g, '\\sqrt ');
-        s = s.replace(/([_^])([a-zA-Z0-9]{2,}(?:\.[0-9]+)?)/g, '$1{$2}');
+        s = s.replace(/~/g, '\\sim ');
+        s = s.replace(/([_^])([a-zA-Z0-9]+(?:\.[0-9]+)?)/g, '$1{$2}');
         s = s.replace(/\b(softmax|argmax|argmin|log10|log|exp|sin|cos|tanh|max|min|KL|Tr|Var|sqrt)\b(\s*\()/g, '\\operatorname{$1}$2');
         return s;
       }

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -425,6 +425,10 @@
       color: var(--blueprint);
     }
 
+    .lesson-article .math-inline .katex {
+      font-size: 1.04em;
+    }
+
     .lesson-article pre {
       position: relative;
       margin: 20px 0;
@@ -1971,6 +1975,7 @@
 
         initCodeCopy();
         renderMermaidBlocks();
+        renderMathSpans();
         if (window.mountLessonFigures) window.mountLessonFigures(el);
         renderAIPanels();
         buildTOC();
@@ -2484,12 +2489,31 @@
         return cells.map(function (c) { return c.trim(); });
       }
 
+      // zh 特化：上游课程把数学公式写成 inline code（如 `h_t = f(h_{t-1}, x_t)`），
+      // 命中强数学信号且无代码特征的 span 改走 KaTeX 渲染，其余保持 code 原样。
+      // 输入是 HTML 转义后的文本；判定必须保守——漏判只是维持现状，误判会把代码渲染成数学。
+      function looksLikeMath(s) {
+        if (/[一-鿿]/.test(s)) return false;
+        if (s.indexOf('&quot;') !== -1 || s.indexOf('$') !== -1) return false;
+        // 单引号：开引号（前面不是标识符/右括号）按字符串字面量排除；prime 记法如 V(s') 放行
+        if (/(^|[^a-zA-Z0-9)\]])&#39;/.test(s)) return false;
+        if (s.indexOf('*') !== -1) return false;
+        if (/_[a-z]{4,}/.test(s)) return false;
+        if (/--|::|=&gt;|-&gt;|\/\//.test(s)) return false;
+        return /[_^]\{/.test(s) ||
+          /[½⅓¼·≈≠≤≥±×÷√∇∂∑Σ∏∫πθμσεαβγλδηρτφψωΩΔ∈∉∞∝∀∃²³ᵀ]/.test(s) ||
+          /\^[0-9a-zA-Z(]/.test(s);
+      }
+
       function inlineFormat(text) {
         text = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
         text = text.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
         text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
         text = text.replace(/\*(.+?)\*/g, '<em>$1</em>');
-        text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
+        text = text.replace(/`([^`]+)`/g, function (m, c) {
+          if (looksLikeMath(c)) return '<code class="math-tex" data-tex="' + c + '">' + c + '</code>';
+          return '<code>' + c + '</code>';
+        });
         text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (m, label, href) {
           if (/^https?:\/\/|^mailto:/i.test(href)) {
             return '<a href="' + href + '" target="_blank" rel="noopener">' + label + '</a>';
@@ -2501,6 +2525,46 @@
 
       function slugify(text) {
         return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+      }
+
+      // 把课程里的伪 LaTeX 记法整理成 KaTeX 能吃的形式。
+      // getAttribute 已还原 HTML 实体，这里拿到的是原始文本。
+      function texPreprocess(s) {
+        s = s.replace(/²/g, '^2').replace(/³/g, '^3').replace(/ᵀ/g, '^T');
+        s = s.replace(/([A-Za-zα-ωΑ-Ω])̅/g, '\\bar{$1}');
+        s = s.replace(/([A-Za-zα-ωΑ-Ω])̂/g, '\\hat{$1}');
+        s = s.replace(/ŵ/g, '\\hat{w}').replace(/â/g, '\\hat{a}');
+        s = s.replace(/√/g, '\\sqrt ');
+        s = s.replace(/([_^])([a-zA-Z0-9]{2,}(?:\.[0-9]+)?)/g, '$1{$2}');
+        s = s.replace(/\b(softmax|argmax|argmin|log10|log|exp|sin|cos|tanh|max|min|KL|Tr|Var|sqrt)\b(\s*\()/g, '\\operatorname{$1}$2');
+        return s;
+      }
+
+      // 按需加载 KaTeX 并渲染 math-tex span；任何一步失败都回退原 code 样式。
+      function renderMathSpans() {
+        var spans = document.querySelectorAll('code.math-tex');
+        if (!spans.length) return;
+        var KATEX = 'https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min';
+        if (!document.getElementById('katex-css')) {
+          var link = document.createElement('link');
+          link.id = 'katex-css'; link.rel = 'stylesheet'; link.href = KATEX + '.css';
+          document.head.appendChild(link);
+        }
+        function renderAll() {
+          spans.forEach(function (el) {
+            try {
+              var span = document.createElement('span');
+              span.className = 'math-inline';
+              window.katex.render(texPreprocess(el.getAttribute('data-tex')), span, { throwOnError: true, strict: false });
+              el.replaceWith(span);
+            } catch (e) { el.classList.remove('math-tex'); }
+          });
+        }
+        if (window.katex) { renderAll(); return; }
+        var script = document.createElement('script');
+        script.src = KATEX + '.js';
+        script.onload = renderAll;
+        document.head.appendChild(script);
       }
 
       function renderCodeBlock(code, lang) {


### PR DESCRIPTION
## 问题

上游课程把数学公式写成 inline code（如 \`h_t = f(h_{t-1}, x_t)\`），code 样式下下标、希腊字母完全不可读（上游英文站同病）。全仓 503 课散文区有 ~600 处这类伪 LaTeX 公式。

## 方案（渲染层，源文档零改动）

lesson.html 渲染 inline code 时做保守启发式判定，命中数学模式的 span 改走 KaTeX，其余保持 code 原样：

- **looksLikeMath()**：强信号（`_{`/`^{`、数学 Unicode 符号、`^` 上标）才进；含中文 / 引号字符串 / `*` 代码乘法 / snake_case 长下标 / `->` 等代码特征一律排除。prime 记法 `V(s')` 与字符串字面量按开引号位置区分。
- **texPreprocess()**：伪 LaTeX 整理——`²³ᵀ`→`^`、组合字符 `α̅`/`V̂`→`\bar`/`\hat`、`√`→`\sqrt`、多字符上下标补花括号、`log`/`softmax` 等函数名转 `\operatorname`。
- **renderMathSpans()**：按需加载 KaTeX 0.16.21（jsdelivr，与 mermaid 同 CDN 先例；页面含公式才拉），逐个 try/catch 渲染，**任何失败回退原 code 样式，绝不变差**。

与上游零漂移：不改任何 docs；上游后续新内容自动受益。此改动成为新的 zh 特化（C 类保护项）。

## 验证

- ✅ 全仓语料回归：431 种数学样本命中 376，**渲染成功率 100%（376/376，0 parse error）**
- ✅ 误伤回归：23 种典型代码 span（`main.py`、f-string、`client_id`、`lr_max`、含中文计算式等）**误伤 0**
- ✅ 真实页面实测（本地渲染器 + 线上 main 正文）：`07-why-transformers` 4 公式、`09-policy-gradients-reinforce` 34 公式全部渲染、0 回退
- ✅ 暗色模式：KaTeX 继承正文色，两主题下均清晰
- ✅ `node site/build.js --check` 通过

## 没验证到的（fail-loud）

- 55 种混合记法样本被保守规则排除（如 `y = w^T * x + b` 含 `*`、`ε_uncond` 长下标），维持 code 原样——不变差但也没变好
- 未逐课遍历全部 503 课的实际渲染（语料回归已全量覆盖 span 种类）
- KaTeX CDN 不可达时公式保持 code 样式（fail-safe 已设计，未实际模拟断网测试）