### PR TITLE
feat(site): 行内公式恢复蓝色视觉标注

### DIFF
--- a/site/lesson.html
+++ b/site/lesson.html
@@ -425,6 +425,13 @@
       color: var(--blueprint);
     }
 
+    .lesson-article .math-inline {
+      background: var(--code-bg);
+      padding: 1px 6px;
+      border: 1px solid var(--rule-soft);
+      color: var(--blueprint);
+    }
+
     .lesson-article .math-inline .katex {
       font-size: 1.04em;
     }


### PR DESCRIPTION
5 行纯 CSS：.math-inline 套用与 inline code 一致的蓝字/浅背景/细边框，KaTeX 公式与代码框共享视觉语言。两主题本地实测正常（亮色截图见会话，暗色 computed style 验证 color rgb(107,142,255) / bg rgb(19,24,48)）。不动判定与渲染逻辑。