### PR TITLE
chore(robots): 显式放行中文搜索引擎蜘蛛

### DIFF
--- a/site/robots.txt
+++ b/site/robots.txt
@@ -10,6 +10,24 @@ Allow: /
 User-agent: DuckDuckBot
 Allow: /
 
+# --- Allowed: 中文搜索引擎（目标读者在国内，显式放行）---
+# Bytespider 同时喂头条/抖音搜索和豆包，接受其抓取训练的代价换国内分发入口；
+# PetalBot 是华为花瓣搜索（上游模板把它当 SEO scraper 封了，对中文站是误伤）。
+User-agent: Baiduspider
+Allow: /
+
+User-agent: Sogou web spider
+Allow: /
+
+User-agent: 360Spider
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: PetalBot
+Allow: /
+
 # --- Allowed: agent browsers (user-initiated, send AI users) ---
 User-agent: ChatGPT-User
 Allow: /
@@ -63,9 +81,6 @@ Disallow: /
 User-agent: Applebot-Extended
 Disallow: /
 
-User-agent: Bytespider
-Disallow: /
-
 User-agent: Amazonbot
 Disallow: /
 
@@ -110,9 +125,6 @@ User-agent: MJ12bot
 Disallow: /
 
 User-agent: DotBot
-Disallow: /
-
-User-agent: PetalBot
 Disallow: /
 
 User-agent: BLEXBot


### PR DESCRIPTION
Bytespider（头条/抖音搜索、豆包入口）和 PetalBot（华为花瓣搜索）此前被上游反 AI 训练 robots 模板封禁。本站目标读者全在国内，解封换分发入口；同时给百度/搜狗/360 补显式 Allow 条目固化意图（原本仅靠 `User-agent: *` 兜底）。

取舍说明：放行 Bytespider 意味着接受字节用内容训练模型，fancy 已确认接受。

验证：grep 确认两个 UA 的 Disallow 块已删、Allow 组无重复 UA 冲突；robots.txt 对同一 UA 只剩一个 group。