### PR TITLE
feat(site): 视频源迁自定义域 + 接入 phase-2 机器学习基础 18 节

### DIFF
--- a/site/videos.json
+++ b/site/videos.json
@@ -1,111 +1,111 @@
 {
   "phases/01-math-foundations/10-dimensionality-reduction": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-10-dimensionality-reduction.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-10-dimensionality-reduction.mp4",
     "bilibili": null,
     "slug": "01-10-dimensionality-reduction"
   },
   "phases/01-math-foundations/11-singular-value-decomposition": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-11-svd.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-11-svd.mp4",
     "bilibili": null,
     "slug": "01-11-svd"
   },
   "phases/01-math-foundations/14-norms-and-distances": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-14-norms-and-distances.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-14-norms-and-distances.mp4",
     "bilibili": null,
     "slug": "01-14-norms-and-distances"
   },
   "phases/01-math-foundations/03-matrix-transformations": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-03-matrix-transformations.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-03-matrix-transformations.mp4",
     "bilibili": null,
     "slug": "01-03-matrix-transformations"
   },
   "phases/01-math-foundations/01-linear-algebra-intuition": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-01-linear-algebra.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-01-linear-algebra.mp4",
     "bilibili": null,
     "slug": "01-01-linear-algebra"
   },
   "phases/01-math-foundations/02-vectors-matrices-operations": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-02-vectors-matrices.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-02-vectors-matrices.mp4",
     "bilibili": null,
     "slug": "01-02-vectors-matrices"
   },
   "phases/01-math-foundations/04-calculus-for-ml": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-04-calculus.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-04-calculus.mp4",
     "bilibili": null,
     "slug": "01-04-calculus"
   },
   "phases/01-math-foundations/05-chain-rule-and-autodiff": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-05-chain-rule-autodiff.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-05-chain-rule-autodiff.mp4",
     "bilibili": null,
     "slug": "01-05-chain-rule-autodiff"
   },
   "phases/01-math-foundations/06-probability-and-distributions": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-06-probability.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-06-probability.mp4",
     "bilibili": null,
     "slug": "01-06-probability"
   },
   "phases/01-math-foundations/08-optimization": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-08-optimization.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-08-optimization.mp4",
     "bilibili": null,
     "slug": "01-08-optimization"
   },
   "phases/01-math-foundations/12-tensor-operations": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-12-tensors.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-12-tensors.mp4",
     "bilibili": null,
     "slug": "01-12-tensors"
   },
   "phases/01-math-foundations/17-linear-systems": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-17-linear-systems.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-17-linear-systems.mp4",
     "bilibili": null,
     "slug": "01-17-linear-systems"
   },
   "phases/01-math-foundations/07-bayes-theorem": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-07-bayes-theorem.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-07-bayes-theorem.mp4",
     "bilibili": null,
     "slug": "01-07-bayes-theorem"
   },
   "phases/01-math-foundations/09-information-theory": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-09-information-theory.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-09-information-theory.mp4",
     "bilibili": null,
     "slug": "01-09-information-theory"
   },
   "phases/01-math-foundations/13-numerical-stability": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-13-numerical-stability.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-13-numerical-stability.mp4",
     "bilibili": null,
     "slug": "01-13-numerical-stability"
   },
   "phases/01-math-foundations/15-statistics-for-ml": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-15-statistics.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-15-statistics.mp4",
     "bilibili": null,
     "slug": "01-15-statistics"
   },
   "phases/01-math-foundations/16-sampling-methods": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-16-sampling.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-16-sampling.mp4",
     "bilibili": null,
     "slug": "01-16-sampling"
   },
   "phases/01-math-foundations/18-convex-optimization": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-18-convex-optimization.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-18-convex-optimization.mp4",
     "bilibili": null,
     "slug": "01-18-convex-optimization"
   },
   "phases/01-math-foundations/20-fourier-transform": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-20-fourier.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-20-fourier.mp4",
     "bilibili": null,
     "slug": "01-20-fourier"
   },
   "phases/01-math-foundations/19-complex-numbers": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-19-complex-numbers.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-19-complex-numbers.mp4",
     "bilibili": null,
     "slug": "01-19-complex-numbers"
   },
   "phases/01-math-foundations/21-graph-theory": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-21-graph-theory.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-21-graph-theory.mp4",
     "bilibili": null,
     "slug": "01-21-graph-theory"
   },
   "phases/01-math-foundations/22-stochastic-processes": {
-    "r2": "https://pub-e80e3f5557334e5eb1e9d78394c9918a.r2.dev/lessons/01-22-stochastic-processes.mp4",
+    "r2": "https://videos.aieng-zh.cn/lessons/01-22-stochastic-processes.mp4",
     "bilibili": null,
     "slug": "01-22-stochastic-processes"
   }

--- a/site/videos.json
+++ b/site/videos.json
@@ -108,5 +108,95 @@
     "r2": "https://videos.aieng-zh.cn/lessons/01-22-stochastic-processes.mp4",
     "bilibili": null,
     "slug": "01-22-stochastic-processes"
+  },
+  "phases/02-ml-fundamentals/01-what-is-machine-learning": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-01-what-is-machine-learning.mp4",
+    "bilibili": null,
+    "slug": "02-01-what-is-machine-learning"
+  },
+  "phases/02-ml-fundamentals/02-linear-regression": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-02-linear-regression.mp4",
+    "bilibili": null,
+    "slug": "02-02-linear-regression"
+  },
+  "phases/02-ml-fundamentals/03-logistic-regression": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-03-logistic-regression.mp4",
+    "bilibili": null,
+    "slug": "02-03-logistic-regression"
+  },
+  "phases/02-ml-fundamentals/04-decision-trees": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-04-decision-trees.mp4",
+    "bilibili": null,
+    "slug": "02-04-decision-trees"
+  },
+  "phases/02-ml-fundamentals/05-support-vector-machines": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-05-support-vector-machines.mp4",
+    "bilibili": null,
+    "slug": "02-05-support-vector-machines"
+  },
+  "phases/02-ml-fundamentals/06-knn-and-distances": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-06-knn-and-distances.mp4",
+    "bilibili": null,
+    "slug": "02-06-knn-and-distances"
+  },
+  "phases/02-ml-fundamentals/07-unsupervised-learning": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-07-unsupervised-learning.mp4",
+    "bilibili": null,
+    "slug": "02-07-unsupervised-learning"
+  },
+  "phases/02-ml-fundamentals/08-feature-engineering": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-08-feature-engineering.mp4",
+    "bilibili": null,
+    "slug": "02-08-feature-engineering"
+  },
+  "phases/02-ml-fundamentals/09-model-evaluation": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-09-model-evaluation.mp4",
+    "bilibili": null,
+    "slug": "02-09-model-evaluation"
+  },
+  "phases/02-ml-fundamentals/10-bias-variance": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-10-bias-variance.mp4",
+    "bilibili": null,
+    "slug": "02-10-bias-variance"
+  },
+  "phases/02-ml-fundamentals/11-ensemble-methods": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-11-ensemble-methods.mp4",
+    "bilibili": null,
+    "slug": "02-11-ensemble-methods"
+  },
+  "phases/02-ml-fundamentals/12-hyperparameter-tuning": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-12-hyperparameter-tuning.mp4",
+    "bilibili": null,
+    "slug": "02-12-hyperparameter-tuning"
+  },
+  "phases/02-ml-fundamentals/13-ml-pipelines": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-13-ml-pipelines.mp4",
+    "bilibili": null,
+    "slug": "02-13-ml-pipelines"
+  },
+  "phases/02-ml-fundamentals/14-naive-bayes": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-14-naive-bayes.mp4",
+    "bilibili": null,
+    "slug": "02-14-naive-bayes"
+  },
+  "phases/02-ml-fundamentals/15-time-series": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-15-time-series.mp4",
+    "bilibili": null,
+    "slug": "02-15-time-series"
+  },
+  "phases/02-ml-fundamentals/16-anomaly-detection": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-16-anomaly-detection.mp4",
+    "bilibili": null,
+    "slug": "02-16-anomaly-detection"
+  },
+  "phases/02-ml-fundamentals/17-imbalanced-data": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-17-imbalanced-data.mp4",
+    "bilibili": null,
+    "slug": "02-17-imbalanced-data"
+  },
+  "phases/02-ml-fundamentals/18-feature-selection": {
+    "r2": "https://videos.aieng-zh.cn/lessons/02-18-feature-selection.mp4",
+    "bilibili": null,
+    "slug": "02-18-feature-selection"
   }
 }


### PR DESCRIPTION
## 概要

本分支围绕"课程视频接入",含两个提交:

1. **视频源迁移**(838680be):phase-1 的 22 节视频 URL 从非生产 `pub-*.r2.dev` 切到自定义域 `videos.aieng-zh.cn`(走 Cloudflare CDN)。
2. **接入 phase-2**(e762ebfb):`02-ml-fundamentals` 全 18 节视频讲解登记进 `site/videos.json`,同样走 `videos.aieng-zh.cn`。

改动仅 `site/videos.json`。mp4 二进制不入 git——托管在 R2,经自定义域下发。

## phase-2 成片规格(18 节全验)

- **1920x1080 h264 + aac**,时长 199–333s(3.3~5.5 分钟),单片 11–20MB。
- **音频**:mean ~−22dB(无静音),max −0.5~−3.0dB(无削波)。
- **两道程序门全过**:measure(SVG 无撞字/溢出)+ motioncheck(10/10 场景有运动)。
- **系列 bumper**:intro 帧逐节确认(FIG 编号 / 标题卡 / 站点标识)。

## 站点接入机制(无需重烤课页)

`lesson.html` 运行时 `fetch('/videos.json')`,按 `lessonPath`(如 `phases/02-ml-fundamentals/01-what-is-machine-learning`)取 key 挂载播放器。预渲染课页已含 `<video>` 壳,故仅改 manifest 即生效。

## 真实验证(代码之外)

本地起静态站 + Chrome DevTools 打开 `02-01` 课页:
- 播放器挂载成功,`video.src = https://videos.aieng-zh.cn/lessons/02-01-what-is-machine-learning.mp4`
- `readyState=4`、解码 `1920x1080`、`duration=209` 与成片一致、`error=null`
- 截图确认视频实际播放(0:26 / 3:28)。

## 未覆盖(fail-loud)

- outro bumper 仅机制同源,未逐节抽帧;intro 仅肉眼核 3/18,其余按 PNG 体积代理判非黑。
- 未通看全片,**音画同步 / 旁白吐字正确性未逐节听过**。
- 内容事实仅回看过 02-14(朴素贝叶斯);其余各节正文帧未逐节核事实。