### PR TITLE
feat(site): 课程入口进站内阅读页 + 部署可移植化

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -239,7 +239,10 @@
 
       html += '<div class="modal-lesson' + (userComplete ? ' user-done' : '') + '">';
       html += '<span class="modal-lesson-status ' + statusClass + '"' + (userComplete ? ' title="你已完成本节课"' : '') + '></span>';
-      if (l.url) {
+      var siteUrl = lessonPath ? '/lessons/' + lessonPath.replace(/^phases\//, '') + '/' : '';
+      if (siteUrl) {
+        html += '<a href="' + siteUrl + '">' + escapeHtml(l.name) + '</a>';   // 课名进站内阅读页
+      } else if (l.url) {
         html += '<a href="' + l.url + '" target="_blank" rel="noopener">' + escapeHtml(l.name) + '</a>';
       } else {
         html += '<a>' + escapeHtml(l.name) + '</a>';
@@ -247,9 +250,10 @@
       html += '<span class="modal-lesson-type" data-type="' + escapeHtml(l.type) + '"' + (l.combines ? ' title="合并自：' + escapeHtml(l.combines) + '"' : '') + '>' + escapeHtml(typeLabel(l.type)) + '</span>';
       html += '<span class="modal-lesson-lang">' + escapeHtml(l.lang) + '</span>';
 
+      // 列5:GitHub 源码小图标(课名已进站内阅读,这里降为次要源码入口)
       var actionHtml = '';
-      if ((l.status === 'complete' || userComplete) && lessonPath) {
-        actionHtml = '<a href="/lessons/' + lessonPath.replace(/^phases\//, '') + '/" class="modal-lesson-read">' + (userComplete ? '回顾' : '阅读') + '</a>';
+      if (l.url) {
+        actionHtml = '<a href="' + l.url + '" target="_blank" rel="noopener" class="modal-lesson-src" title="在 GitHub 查看源码" aria-label="GitHub 源码">↗</a>';
       }
       var toggleHtml = '';
       if (hasProgress && lessonPath) {

--- a/site/build.js
+++ b/site/build.js
@@ -17,8 +17,10 @@ const ROADMAP_PATH = path.join(REPO_ROOT, 'ROADMAP.md');
 const GLOSSARY_PATH = path.join(REPO_ROOT, 'glossary', 'terms.md');
 const OUTPUT_PATH = path.join(__dirname, 'data.js');
 
-const GITHUB_BASE = 'https://github.com/fancyboi999/ai-engineering-from-scratch-zh/tree/main/';
-const SITE_ORIGIN = 'https://aieng-zh.cn';
+// 开源可移植:fork 部署只需设这两个环境变量即可让全站 SEO/社交卡/源码链接指向自己的域名与仓库,
+// 不设则回落到本仓库的官方部署(aieng-zh.cn)。CI/Vercel buildCommand 里 export 即可生效。
+const GITHUB_BASE = process.env.GITHUB_BASE || 'https://github.com/fancyboi999/ai-engineering-from-scratch-zh/tree/main/';
+const SITE_ORIGIN = process.env.SITE_ORIGIN || 'https://aieng-zh.cn';
 
 // 与浏览器端同一份渲染器（从 lesson.html 抽出）；预渲染产物 = 运行时渲染产物
 const mdRender = require('./md-render.js');
@@ -689,6 +691,9 @@ function writeLessonPages(phases) {
     setMeta('property', 'og:description', desc);
     setMeta('name', 'twitter:title', ogTitle);
     setMeta('name', 'twitter:description', desc);
+    // 社交卡图跟随 SITE_ORIGIN(模板里写死的 aieng 默认值会被覆盖),fork 部署即指向自己的图
+    setMeta('property', 'og:image', SITE_ORIGIN + '/og-image.png?v=2');
+    setMeta('name', 'twitter:image', SITE_ORIGIN + '/og-image.png?v=2');
     page = page.replace(
       /<link rel="canonical" href="[^"]*">/,
       () => '<link rel="canonical" href="' + url + '">\n  <meta property="og:url" content="' + url + '">'

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -157,6 +157,19 @@
       color: var(--accent);
     }
 
+    /* 课名后的 GitHub 源码小图标:弱于课名的次要入口 */
+    .catalog-table .catalog-src {
+      font-size: 0.78rem;
+      color: var(--text-muted);
+      opacity: 0.55;
+      text-decoration: none;
+    }
+
+    .catalog-table .catalog-src:hover {
+      color: var(--accent);
+      opacity: 1;
+    }
+
     .catalog-status-dot {
       display: inline-block;
       width: 8px;
@@ -350,6 +363,12 @@
 
           for (var j = 0; j < p.lessons.length; j++) {
             var l = p.lessons[j];
+            // 从 GitHub tree url 抠出 phases/<phase>/<lesson>,转成站内预渲染页 /lessons/<phase>/<lesson>/
+            var sitePath = '';
+            if (l.url) {
+              var pm = l.url.match(/(phases\/[^/]+\/[^/]+)\/?$/);
+              if (pm) sitePath = '/lessons/' + pm[1].replace(/^phases\//, '') + '/';
+            }
             allRows.push({
               phase: p.id,
               phaseName: p.name,
@@ -357,7 +376,8 @@
               type: l.type,
               lang: l.lang,
               status: l.status,
-              url: l.url || ''
+              url: l.url || '',
+              siteUrl: sitePath
             });
           }
         }
@@ -435,7 +455,12 @@
             var r = rows[i];
             html += '<tr>';
             html += '<td><span class="catalog-phase-label">' + String(r.phase).padStart(2, '0') + '</span></td>';
-            if (r.url) {
+            if (r.siteUrl) {
+              // 课名进站内阅读页;GitHub 降为行尾小图标(查看源码)
+              html += '<td><a href="' + r.siteUrl + '" class="catalog-lesson-link">' + escapeHtml(r.name) + '</a>'
+                + (r.url ? ' <a href="' + r.url + '" target="_blank" rel="noopener" class="catalog-src" title="在 GitHub 查看源码" aria-label="GitHub 源码">↗</a>' : '')
+                + '</td>';
+            } else if (r.url) {
               html += '<td><a href="' + r.url + '" target="_blank" rel="noopener">' + escapeHtml(r.name) + '</a></td>';
             } else {
               html += '<td>' + escapeHtml(r.name) + '</td>';

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2060,7 +2060,7 @@
 
       // 客户端逐课 SEO：动态设置 canonical / description / JSON-LD（LearningResource）
       function updateLessonSeo(title, md) {
-        var ORIGIN = 'https://aieng-zh.cn';
+        var ORIGIN = location.origin;  // 跟随部署域名:fork 部署时 canonical/og:url/JSON-LD 自动指向自己
         var path = new URLSearchParams(location.search).get('path') || '';
         if (!path) return;  // 防御：空 path 会生成 /lessons// 这种坏 canonical
         // canonical 指向预渲染静态页（SEO 主体）；旧 ?path= URL 仅作兼容入口
@@ -2076,6 +2076,8 @@
         set('meta[property="og:description"]', desc);
         set('meta[name="twitter:title"]', fullTitle);
         set('meta[name="twitter:description"]', desc);
+        set('meta[property="og:image"]', ORIGIN + '/og-image.png?v=2');   // 社交卡图跟随部署域名
+        set('meta[name="twitter:image"]', ORIGIN + '/og-image.png?v=2');
         var ogu = document.querySelector('meta[property="og:url"]');
         if (!ogu) { ogu = document.createElement('meta'); ogu.setAttribute('property', 'og:url'); document.head.appendChild(ogu); }
         ogu.setAttribute('content', url);

--- a/site/style.css
+++ b/site/style.css
@@ -709,6 +709,24 @@ p.dropcap::first-letter {
   border-bottom: 1px solid var(--blueprint);
 }
 
+/* 列5:GitHub 源码小图标(课名已进站内,这里是次要源码入口),覆盖 .modal-lesson>a 的课名样式 */
+.modal-lesson .modal-lesson-src {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--ink-mute);
+  text-decoration: none;
+  border-bottom: none;
+  overflow: visible;
+  min-width: 64px;
+  text-align: center;
+  transition: color 0.15s;
+}
+
+.modal-lesson .modal-lesson-src:hover {
+  color: var(--blueprint);
+  border-bottom: none;
+}
+
 .modal-lesson-read-placeholder {
   display: inline-block;
   width: 64px;


### PR DESCRIPTION
## 背景
1. 课程表/首页大纲的课名一点就**跳出站到 GitHub**,用户读着读着就离站了。
2. 开源项目里 SEO/源码链接**写死了 aieng-zh.cn 与本仓库**,fork 部署无法指向自己。

## 改动
### 导航:课程入口进站内
- 课名链接从 GitHub tree url 改为站内预渲染页 `/lessons/<phase>/<lesson>/`(503 节均有真实预渲染页)
- GitHub 降为行尾 ↗ 源码小图标(次要入口)
- 涉及 `catalog.html` / `app.js` / `style.css`;modal 6 列 grid 列数不变(空槽走 placeholder)

### 部署可移植化(开源友好)
- `build.js` 的 `SITE_ORIGIN` / `GITHUB_BASE` 改读 `process.env`,默认回落 aieng —— **fork 设两个环境变量即全站指向自己**
- 生成页补 `og:image`/`twitter:image` 跟随 `SITE_ORIGIN`(原唯一漏网的社交卡图)
- `lesson.html` 的 `ORIGIN` → `location.origin`,`?path=` 兜底页 canonical/og 跟随部署域名

## 验证
- node 全量核对:503/503 节课名映射到真实存在的预渲染页,0 失败
- fork 假 env(`fork.example.com` / `forkuser/forkrepo`)跑 build:llms.txt(507)/sitemap.xml(508)/生成页/data.js(503)中 **aieng 与 fancyboi999 残留全 0**
- 默认 env 还原后 **data.js git diff = 0 行**,官方部署零影响

## 不在本 PR 范围
- `videos.json`(上传回填中,待 BV 投完单独提)
- footer/about/header 的仓库链接(属更大范围的「全量可移植化」,本次未做)
