### PR TITLE
feat(progress): 学习进度导出/导入与自动备份同步

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260525a">
+  <link rel="stylesheet" href="style.css?v=20260709a">
   <style>
     .about {
       max-width: 760px;
@@ -166,7 +166,7 @@
   }
   </script>
   <script src="data.js?v=20260525a"></script>
-  <script src="progress.js?v=20260525a"></script>
+  <script src="progress.js?v=20260709a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
   <script>

--- a/site/app.js
+++ b/site/app.js
@@ -20,6 +20,7 @@
     initSmoothScroll();
     initFadeObserver();
     initScrollExplode();
+    bindProgressActions('statExport', 'statImport', 'statImportFile');
   });
 
   function updateThemeIcon() {
@@ -200,6 +201,48 @@
         window.AIFSProgress.reset();
       });
     }
+
+    bindProgressActions('modalExport', 'modalImport', 'modalImportFile');
+  }
+
+  function bindProgressActions(exportId, importId, importFileId) {
+    var exportBtn = document.getElementById(exportId);
+    if (exportBtn) {
+      exportBtn.addEventListener('click', function () {
+        if (!window.AIFSProgress) return;
+        var forcePicker = (exportId === 'statExport');
+        Promise.resolve(window.AIFSProgress.exportJSON(false, forcePicker)).catch(function () {
+          window.alert('导出失败，请稍后重试。');
+        });
+      });
+    }
+
+    var importBtn = document.getElementById(importId);
+    var importFile = document.getElementById(importFileId);
+    if (importBtn && importFile) {
+      importBtn.addEventListener('click', function () {
+        importFile.click();
+      });
+      importFile.addEventListener('change', function () {
+        if (!window.AIFSProgress) return;
+        var file = this.files && this.files[0];
+        if (!file) return;
+        var reader = new FileReader();
+        reader.onload = function () {
+          var result = window.AIFSProgress.importJSON(String(reader.result || ''));
+          if (result && result.ok) {
+            window.alert('进度已导入并合并。');
+          } else {
+            window.alert('导入失败：' + (result && result.error ? result.error : '未知错误。'));
+          }
+        };
+        reader.onerror = function () {
+          window.alert('读取文件失败，请重试。');
+        };
+        reader.readAsText(file);
+        this.value = '';
+      });
+    }
   }
 
   var currentPhaseIdx = -1;
@@ -308,6 +351,8 @@
       renderPhases();
     });
   }
+
+
 
   function closeModal() {
     document.getElementById('modalOverlay').classList.remove('open');

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260525a">
+  <link rel="stylesheet" href="style.css?v=20260709a">
   <style>
     .catalog-page {
       padding: 100px 0 80px;
@@ -315,7 +315,7 @@
   </footer>
 
   <script src="data.js?v=20260525a"></script>
-  <script src="progress.js?v=20260525a"></script>
+  <script src="progress.js?v=20260709a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
   <script>

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260525a">
+  <link rel="stylesheet" href="style.css?v=20260709a">
   <style>
     .glossary-page {
       padding: 100px 0 80px;
@@ -232,7 +232,7 @@
   </footer>
 
   <script src="data.js?v=20260525a"></script>
-  <script src="progress.js?v=20260525a"></script>
+  <script src="progress.js?v=20260709a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
   <script>

--- a/site/index.html
+++ b/site/index.html
@@ -64,7 +64,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260525a">
+  <link rel="stylesheet" href="style.css?v=20260709a">
   <style>
     .manual-masthead {
       padding: 96px 0 24px;
@@ -764,6 +764,12 @@
           <span class="stat-row-value" data-stat="glossary-count">···</span>
         </div>
       </div>
+      <div class="stat-block-actions">
+        <span class="stat-block-note">进度保存在浏览器本地，可导出/导入 JSON 跨设备同步</span>
+        <button class="stat-block-btn" id="statExport" type="button">导出进度</button>
+        <button class="stat-block-btn" id="statImport" type="button">导入进度</button>
+        <input type="file" id="statImportFile" accept="application/json,.json" style="display:none;">
+      </div>
     </section>
 
     <section class="toc container" id="contents">
@@ -789,7 +795,10 @@
         </div>
         <div class="modal-lessons" id="modalLessons"></div>
         <div class="modal-footer">
-          <span class="modal-footer-note">进度仅保存在浏览器本地</span>
+          <span class="modal-footer-note">进度保存在浏览器本地，可导出/导入 JSON 跨设备同步</span>
+          <button class="modal-export" id="modalExport" type="button">导出进度</button>
+          <button class="modal-import" id="modalImport" type="button">导入进度</button>
+          <input type="file" id="modalImportFile" accept="application/json,.json" style="display:none;">
           <button class="modal-reset" id="modalReset" type="button">重置进度</button>
         </div>
       </div>
@@ -824,10 +833,11 @@
   </footer>
 
   <script src="data.js?v=20260525a"></script>
-  <script src="progress.js?v=20260525a"></script>
+  <script src="progress.js?v=20260709a"></script>
+  <script src="reminder.js?v=20260709a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
-  <script src="app.js?v=20260525a"></script>
+  <script src="app.js?v=20260709a"></script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260525a">
+  <link rel="stylesheet" href="style.css?v=20260709a">
   <style>
     .scroll-progress {
       position: fixed;
@@ -1764,7 +1764,8 @@
   <script src="md-render.js?v=20260612a"></script>
   <script src="build-meta.js"></script>
   <script src="data.js?v=20260525a"></script>
-  <script src="progress.js?v=20260525a"></script>
+  <script src="progress.js?v=20260709a"></script>
+  <script src="reminder.js?v=20260709a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
   <script src="figures.js?v=20260610e"></script>

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260525a">
+  <link rel="stylesheet" href="style.css?v=20260709a">
   <style>
     /* ===================================================
        Learning Path — Page Styles
@@ -473,7 +473,7 @@
   </footer>
 
   <script src="data.js?v=20260525a"></script>
-  <script src="progress.js?v=20260525a"></script>
+  <script src="progress.js?v=20260709a"></script>
   <script src="header.js?v=20260525a" defer></script>
   <script src="cmdpalette.js?v=20260525a" defer></script>
   <script>

--- a/site/progress.js
+++ b/site/progress.js
@@ -24,8 +24,6 @@
  */
 (function () {
   var STORAGE_KEY = 'aifs:progress:v1';
-  var REMIND_KEY = 'aifs:progress:remind';
-  var REMIND_THRESHOLD = 1; // completed lessons since last export before nudging
   var listeners = [];
 
   function emptyState() {
@@ -46,14 +44,17 @@
 
   function write(state) {
     state.updatedAt = Date.now();
+    var saved = false;
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      saved = true;
     } catch (e) {
       // quota or disabled storage; fail silently
     }
     for (var i = 0; i < listeners.length; i++) {
       try { listeners[i](state); } catch (_) {}
     }
+    return saved;
   }
 
   function ensureLesson(state, path) {
@@ -145,7 +146,6 @@
 
   function reset() {
     try { localStorage.removeItem(STORAGE_KEY); } catch (e) {}
-    try { localStorage.removeItem(REMIND_KEY); } catch (e) {}
     for (var i = 0; i < listeners.length; i++) {
       try { listeners[i](emptyState()); } catch (_) {}
     }
@@ -165,53 +165,6 @@
     }
   });
 
-  // --- Export reminder: nudge the user to back up after N new completions ---
-  // Remind state is device-local (about THIS device's export habits) and is
-  // intentionally NOT part of the exported progress JSON.
-  // Remind state tracks RELATIVE pending counts, not absolute totals.
-  //   lastExportedTotal: totalCompleted() snapshot at last export/import.
-  //   dismissedPending: pendingExportCount() snapshot at last dismissal.
-  // pending = totalCompleted() - lastExportedTotal  (always >= 0).
-  function getRemindState() {
-    try {
-      var raw = localStorage.getItem(REMIND_KEY);
-      if (raw) {
-        var p = JSON.parse(raw);
-        if (p && typeof p === 'object') {
-          return {
-            lastExportedTotal: typeof p.lastExportedTotal === 'number' ? p.lastExportedTotal : 0,
-            dismissedPending: typeof p.dismissedPending === 'number' ? p.dismissedPending : 0
-          };
-        }
-      }
-    } catch (e) {}
-    return { lastExportedTotal: 0, dismissedPending: 0 };
-  }
-
-  function writeRemindState(s) {
-    try { localStorage.setItem(REMIND_KEY, JSON.stringify(s)); } catch (e) {}
-  }
-
-  function pendingExportCount() {
-    var s = getRemindState();
-    return Math.max(0, totalCompleted() - s.lastExportedTotal);
-  }
-
-  function markExported() {
-    var n = totalCompleted();
-    writeRemindState({ lastExportedTotal: n, dismissedPending: 0 });
-  }
-
-  function dismissReminder() {
-    var p = pendingExportCount();
-    writeRemindState({ lastExportedTotal: getRemindState().lastExportedTotal, dismissedPending: p });
-  }
-
-  function shouldRemind() {
-    var s = getRemindState();
-    var pending = Math.max(0, totalCompleted() - s.lastExportedTotal);
-    return pending >= REMIND_THRESHOLD && (pending - s.dismissedPending) >= REMIND_THRESHOLD;
-  }
   /**
    * Merge a remote state into the local state using per-lesson timestamps.
    * - completedAt: once non-null on either side, stays non-null (completion is irreversible).
@@ -225,16 +178,16 @@
     for (var k in local.lessons) allPaths[k] = true;
     for (var k in remote.lessons) allPaths[k] = true;
     for (var path in allPaths) {
-      var l = local.lessons[path];
-      var r = remote.lessons[path];
-      if (!l) { merged.lessons[path] = r; continue; }
-      if (!r) { merged.lessons[path] = l; continue; }
+      var l = local.lessons[path] || {};
+      var r = remote.lessons[path] || {};
       var mergedAnswers = {};
       var allQids = {};
-      for (var q in l.answers) allQids[q] = true;
-      for (var q in r.answers) allQids[q] = true;
+      var lAnswers = l.answers || {};
+      var rAnswers = r.answers || {};
+      for (var q in lAnswers) allQids[q] = true;
+      for (var q in rAnswers) allQids[q] = true;
       for (var qid in allQids) {
-        var la = l.answers[qid], ra = r.answers[qid];
+        var la = lAnswers[qid], ra = rAnswers[qid];
         if (!la) { mergedAnswers[qid] = ra; continue; }
         if (!ra) { mergedAnswers[qid] = la; continue; }
         mergedAnswers[qid] = (la.t || 0) >= (ra.t || 0) ? la : ra;
@@ -305,6 +258,18 @@
     });
   }
 
+  async function canAutoExport() {
+    if (!window.showSaveFilePicker) return false;
+    try {
+      var handle = await getStoredHandle();
+      if (!handle) return false;
+      if (!handle.queryPermission) return false;
+      return await handle.queryPermission({ mode: 'readwrite' }) === 'granted';
+    } catch (e) {
+      return false;
+    }
+  }
+
   async function writeHandle(handle, text) {
     var writable = await handle.createWritable();
     await writable.write(text);
@@ -367,13 +332,13 @@
             : 'prompt';
           if (perm === 'granted') {
             await writeHandle(handle, json);
-            return markExported(), true;
+            return true;
           }
           if (!silent && perm === 'prompt' && handle.requestPermission) {
             var granted = await handle.requestPermission({ mode: 'readwrite' });
             if (granted === 'granted') {
               await writeHandle(handle, json);
-              return markExported(), true;
+              return true;
             }
             // denied -> fall through to picker
           } else if (silent) {
@@ -388,7 +353,7 @@
         });
         await writeHandle(handle, json);
         await setStoredHandle(handle);
-        return markExported(), true;
+        return true;
       } catch (e) {
         if (e && e.name === 'AbortError') return false; // user cancelled
         // other error -> fall through to legacy download
@@ -396,7 +361,6 @@
     }
 
     var ok = legacyDownload(json);
-    if (ok) markExported();
     return ok;
   }
 
@@ -428,11 +392,19 @@
     if (version != null && version !== SCHEMA_VERSION) {
       return { ok: false, error: '版本不匹配：文件版本为 v' + version + '，当前支持 v' + SCHEMA_VERSION + '。' };
     }
-    var local = read();
-    var merged = mergeStates(local, { lessons: lessons, updatedAt: remote.updatedAt || 0 });
-    write(merged);
-    markExported(); // imported data is itself a backup baseline
-    return { ok: true };
+    if (typeof lessons !== 'object' || Array.isArray(lessons)) {
+      return { ok: false, error: '文件结构不正确：lessons 必须是对象。' };
+    }
+    try {
+      var local = read();
+      var merged = mergeStates(local, { lessons: lessons, updatedAt: remote.updatedAt || 0 });
+      if (!write(merged)) {
+        return { ok: false, error: '导入失败：浏览器无法保存进度。' };
+      }
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: '导入失败：无法合并或保存进度。' };
+    }
   }
   window.AIFSProgress = {
     recordVisit: recordVisit,
@@ -446,12 +418,9 @@
     totalCompleted: totalCompleted,
     reset: reset,
     exportJSON: exportJSON,
+    canAutoExport: canAutoExport,
     importJSON: importJSON,
     mergeStates: mergeStates,
-    markExported: markExported,
-    dismissReminder: dismissReminder,
-    pendingExportCount: pendingExportCount,
-    shouldRemind: shouldRemind,
     onChange: onChange,
   };
 })();

--- a/site/progress.js
+++ b/site/progress.js
@@ -24,6 +24,8 @@
  */
 (function () {
   var STORAGE_KEY = 'aifs:progress:v1';
+  var REMIND_KEY = 'aifs:progress:remind';
+  var REMIND_THRESHOLD = 1; // completed lessons since last export before nudging
   var listeners = [];
 
   function emptyState() {
@@ -90,8 +92,13 @@
   function unmarkLessonComplete(path) {
     if (!path) return;
     var state = read();
-    if (state.lessons[path] && state.lessons[path].completedAt) {
-      state.lessons[path].completedAt = null;
+    var lesson = state.lessons[path];
+    if (lesson && lesson.completedAt) {
+      delete lesson.completedAt;
+      // 若该课再无任何学习痕迹，整个条目也没必要留着
+      if (!lesson.visitedAt && (!lesson.answers || Object.keys(lesson.answers).length === 0)) {
+        delete state.lessons[path];
+      }
       write(state);
     }
   }
@@ -138,6 +145,7 @@
 
   function reset() {
     try { localStorage.removeItem(STORAGE_KEY); } catch (e) {}
+    try { localStorage.removeItem(REMIND_KEY); } catch (e) {}
     for (var i = 0; i < listeners.length; i++) {
       try { listeners[i](emptyState()); } catch (_) {}
     }
@@ -157,6 +165,275 @@
     }
   });
 
+  // --- Export reminder: nudge the user to back up after N new completions ---
+  // Remind state is device-local (about THIS device's export habits) and is
+  // intentionally NOT part of the exported progress JSON.
+  // Remind state tracks RELATIVE pending counts, not absolute totals.
+  //   lastExportedTotal: totalCompleted() snapshot at last export/import.
+  //   dismissedPending: pendingExportCount() snapshot at last dismissal.
+  // pending = totalCompleted() - lastExportedTotal  (always >= 0).
+  function getRemindState() {
+    try {
+      var raw = localStorage.getItem(REMIND_KEY);
+      if (raw) {
+        var p = JSON.parse(raw);
+        if (p && typeof p === 'object') {
+          return {
+            lastExportedTotal: typeof p.lastExportedTotal === 'number' ? p.lastExportedTotal : 0,
+            dismissedPending: typeof p.dismissedPending === 'number' ? p.dismissedPending : 0
+          };
+        }
+      }
+    } catch (e) {}
+    return { lastExportedTotal: 0, dismissedPending: 0 };
+  }
+
+  function writeRemindState(s) {
+    try { localStorage.setItem(REMIND_KEY, JSON.stringify(s)); } catch (e) {}
+  }
+
+  function pendingExportCount() {
+    var s = getRemindState();
+    return Math.max(0, totalCompleted() - s.lastExportedTotal);
+  }
+
+  function markExported() {
+    var n = totalCompleted();
+    writeRemindState({ lastExportedTotal: n, dismissedPending: 0 });
+  }
+
+  function dismissReminder() {
+    var p = pendingExportCount();
+    writeRemindState({ lastExportedTotal: getRemindState().lastExportedTotal, dismissedPending: p });
+  }
+
+  function shouldRemind() {
+    var s = getRemindState();
+    var pending = Math.max(0, totalCompleted() - s.lastExportedTotal);
+    return pending >= REMIND_THRESHOLD && (pending - s.dismissedPending) >= REMIND_THRESHOLD;
+  }
+  /**
+   * Merge a remote state into the local state using per-lesson timestamps.
+   * - completedAt: once non-null on either side, stays non-null (completion is irreversible).
+   *   If both sides completed, keep the earlier timestamp (first completion time).
+   * - answers: per qid, keep the entry with the larger t (later answer wins).
+   * - visitedAt: keep the larger value.
+   */
+  function mergeStates(local, remote) {
+    var merged = { lessons: {}, updatedAt: Math.max(local.updatedAt || 0, remote.updatedAt || 0) };
+    var allPaths = {};
+    for (var k in local.lessons) allPaths[k] = true;
+    for (var k in remote.lessons) allPaths[k] = true;
+    for (var path in allPaths) {
+      var l = local.lessons[path];
+      var r = remote.lessons[path];
+      if (!l) { merged.lessons[path] = r; continue; }
+      if (!r) { merged.lessons[path] = l; continue; }
+      var mergedAnswers = {};
+      var allQids = {};
+      for (var q in l.answers) allQids[q] = true;
+      for (var q in r.answers) allQids[q] = true;
+      for (var qid in allQids) {
+        var la = l.answers[qid], ra = r.answers[qid];
+        if (!la) { mergedAnswers[qid] = ra; continue; }
+        if (!ra) { mergedAnswers[qid] = la; continue; }
+        mergedAnswers[qid] = (la.t || 0) >= (ra.t || 0) ? la : ra;
+      }
+      var completedAt = null;
+      if (l.completedAt && r.completedAt) {
+        completedAt = Math.min(l.completedAt, r.completedAt);
+      } else {
+        completedAt = l.completedAt || r.completedAt;
+      }
+      merged.lessons[path] = {
+        answers: mergedAnswers,
+        completedAt: completedAt,
+        visitedAt: Math.max(l.visitedAt || 0, r.visitedAt || 0)
+      };
+    }
+    return merged;
+  }
+
+  // --- File System Access API: remember a save location across sessions ---
+  // On Chrome/Edge the user picks a save file once; the handle is persisted
+  // in IndexedDB so later exports overwrite the same file without re-prompting.
+  var FS_DB = 'aifs:fs';
+  var FS_STORE = 'handles';
+  var FS_KEY = 'progress-export';
+
+  function openFSDB() {
+    return new Promise(function (resolve) {
+      if (!window.indexedDB) { resolve(null); return; }
+      try {
+        var req = indexedDB.open(FS_DB, 1);
+        req.onupgradeneeded = function () {
+          if (!req.result.objectStoreNames.contains(FS_STORE)) {
+            req.result.createObjectStore(FS_STORE);
+          }
+        };
+        req.onsuccess = function () { resolve(req.result); };
+        req.onerror = function () { resolve(null); };
+      } catch (e) { resolve(null); }
+    });
+  }
+
+  function getStoredHandle() {
+    return openFSDB().then(function (db) {
+      if (!db) return null;
+      return new Promise(function (resolve) {
+        try {
+          var tx = db.transaction(FS_STORE, 'readonly');
+          var req = tx.objectStore(FS_STORE).get(FS_KEY);
+          req.onsuccess = function () { resolve(req.result || null); };
+          req.onerror = function () { resolve(null); };
+        } catch (e) { resolve(null); }
+      });
+    });
+  }
+
+  function setStoredHandle(handle) {
+    return openFSDB().then(function (db) {
+      if (!db) return;
+      return new Promise(function (resolve) {
+        try {
+          var tx = db.transaction(FS_STORE, 'readwrite');
+          tx.objectStore(FS_STORE).put(handle, FS_KEY);
+          tx.oncomplete = function () { resolve(); };
+          tx.onerror = function () { resolve(); };
+        } catch (e) { resolve(); }
+      });
+    });
+  }
+
+  async function writeHandle(handle, text) {
+    var writable = await handle.createWritable();
+    await writable.write(text);
+    await writable.close();
+  }
+
+  var SCHEMA_VERSION = 1;
+
+  function dateStamp() {
+    var d = new Date();
+    var p = function (n) { return String(n).padStart(2, '0'); };
+    return d.getFullYear() + '-' + p(d.getMonth() + 1) + '-' + p(d.getDate());
+  }
+
+  // Wrap the raw localStorage state with schema metadata for export.
+  function buildExportPayload(state) {
+    return {
+      schema: 'aifs:progress',
+      version: SCHEMA_VERSION,
+      exportedAt: Date.now(),
+      lessons: state.lessons,
+      updatedAt: state.updatedAt
+    };
+  }
+  function legacyDownload(json) {
+    try {
+      var blob = new Blob([json], { type: 'application/json' });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = 'aifs-progress-' + dateStamp() + '.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Export progress as JSON. Returns a Promise<boolean>.
+   * On Chrome/Edge uses the File System Access API so the user can pick a
+   * save location; the chosen file handle is remembered in IndexedDB and
+   * overwritten on later exports. Falls back to a normal download where the
+   * API is unavailable. Returns false if the user cancels the picker.
+   */
+  async function exportJSON(silent, forcePicker) {
+    var state = read();
+    var payload = buildExportPayload(state);
+    var json = JSON.stringify(payload, null, 2);
+
+    if (window.showSaveFilePicker) {
+      try {
+        var handle = forcePicker ? null : await getStoredHandle();
+        if (handle) {
+          var perm = handle.queryPermission
+            ? await handle.queryPermission({ mode: 'readwrite' })
+            : 'prompt';
+          if (perm === 'granted') {
+            await writeHandle(handle, json);
+            return markExported(), true;
+          }
+          if (!silent && perm === 'prompt' && handle.requestPermission) {
+            var granted = await handle.requestPermission({ mode: 'readwrite' });
+            if (granted === 'granted') {
+              await writeHandle(handle, json);
+              return markExported(), true;
+            }
+            // denied -> fall through to picker
+          } else if (silent) {
+            // Silent mode: have a handle but permission not granted -> skip.
+            return false;
+          }
+        }
+        if (silent) return false; // no stored handle in silent mode -> skip
+        handle = await window.showSaveFilePicker({
+          suggestedName: 'aifs-progress-' + dateStamp() + '.json',
+          types: [{ description: 'JSON', accept: { 'application/json': ['.json'] } }]
+        });
+        await writeHandle(handle, json);
+        await setStoredHandle(handle);
+        return markExported(), true;
+      } catch (e) {
+        if (e && e.name === 'AbortError') return false; // user cancelled
+        // other error -> fall through to legacy download
+      }
+    }
+
+    var ok = legacyDownload(json);
+    if (ok) markExported();
+    return ok;
+  }
+
+  /**
+   * Parse an imported JSON string and merge it into local state.
+   * Returns true on success, false if the input is invalid.
+   */
+  // Returns { ok: true } on success, or { ok: false, error: '...' } on failure.
+  function importJSON(text) {
+    var remote;
+    try {
+      remote = JSON.parse(text);
+    } catch (e) {
+      return { ok: false, error: 'JSON 解析失败：文件内容不是有效的 JSON。' };
+    }
+    if (!remote || typeof remote !== 'object') {
+      return { ok: false, error: '文件结构不正确：缺少 lessons 对象。' };
+    }
+    // Accept both wrapped (with schema/version) and raw localStorage dumps.
+    var version = remote.version;
+    var lessons = remote.lessons;
+    if (!lessons && remote.schema === 'aifs:progress') {
+      // Wrapped payload but missing lessons -> corrupt
+      return { ok: false, error: '文件已损坏：缺少 lessons 对象。' };
+    }
+    if (!lessons) {
+      return { ok: false, error: '文件结构不正确：缺少 lessons 对象。' };
+    }
+    if (version != null && version !== SCHEMA_VERSION) {
+      return { ok: false, error: '版本不匹配：文件版本为 v' + version + '，当前支持 v' + SCHEMA_VERSION + '。' };
+    }
+    var local = read();
+    var merged = mergeStates(local, { lessons: lessons, updatedAt: remote.updatedAt || 0 });
+    write(merged);
+    markExported(); // imported data is itself a backup baseline
+    return { ok: true };
+  }
   window.AIFSProgress = {
     recordVisit: recordVisit,
     recordAnswer: recordAnswer,
@@ -168,6 +445,13 @@
     extractPath: extractPath,
     totalCompleted: totalCompleted,
     reset: reset,
+    exportJSON: exportJSON,
+    importJSON: importJSON,
+    mergeStates: mergeStates,
+    markExported: markExported,
+    dismissReminder: dismissReminder,
+    pendingExportCount: pendingExportCount,
+    shouldRemind: shouldRemind,
     onChange: onChange,
   };
 })();

--- a/site/reminder.js
+++ b/site/reminder.js
@@ -86,27 +86,72 @@
   // progress changes. Only runs when a file handle with write access already
   // exists -- never pops a picker. Debounced so bursts of changes write once.
   var autoExportTimer = null;
+  var autoExportRequest = 0;
+  var exportInFlight = false;
+  var queuedExportRequest = 0;
+
+  function runAutoExport(request) {
+    if (exportInFlight) {
+      queuedExportRequest = Math.max(queuedExportRequest, request);
+      return;
+    }
+    exportInFlight = true;
+    Promise.resolve(window.AIFSProgress.exportJSON(true)).then(function (ok) {
+      exportInFlight = false;
+      if (queuedExportRequest) {
+        var queued = queuedExportRequest;
+        queuedExportRequest = 0;
+        runAutoExport(queued);
+        return;
+      }
+      if (request !== autoExportRequest) return;
+      setSaveState(ok ? 'saved' : 'idle');
+      scheduleHide(ok ? 1800 : 600);
+    }).catch(function () {
+      exportInFlight = false;
+      if (queuedExportRequest) {
+        var queued = queuedExportRequest;
+        queuedExportRequest = 0;
+        runAutoExport(queued);
+        return;
+      }
+      if (request !== autoExportRequest) return;
+      setSaveState('idle');
+      scheduleHide(600);
+    });
+  }
+
   function scheduleAutoExport() {
-    if (!window.AIFSProgress || !window.AIFSProgress.exportJSON) return;
+    if (!window.AIFSProgress || !window.AIFSProgress.exportJSON || !window.AIFSProgress.canAutoExport) return;
     if (autoExportTimer) clearTimeout(autoExportTimer);
+    var request = ++autoExportRequest;
     show();
-    setSaveState('saving');
-    autoExportTimer = setTimeout(function () {
-      autoExportTimer = null;
-      Promise.resolve(window.AIFSProgress.exportJSON(true)).then(function (ok) {
-        setSaveState(ok ? 'saved' : 'idle');
-        // hold the "saved" state briefly, then fade out
-        scheduleHide(ok ? 1800 : 600);
-      }).catch(function () {
-        setSaveState('idle');
-        scheduleHide(600);
-      });
-    }, 2000);
+    setSaveState('idle');
+    Promise.resolve(window.AIFSProgress.canAutoExport()).then(function (canExport) {
+      if (request !== autoExportRequest) return;
+      if (!canExport) {
+        scheduleHide(2400);
+        return;
+      }
+      setSaveState('saving');
+      autoExportTimer = setTimeout(function () {
+        autoExportTimer = null;
+        runAutoExport(request);
+      }, 2000);
+    }).catch(function () {
+      if (request === autoExportRequest) scheduleHide(2400);
+    });
   }
 
   function init() {
     if (!window.AIFSProgress) return;
-    window.AIFSProgress.onChange(scheduleAutoExport);
+    var completed = window.AIFSProgress.totalCompleted();
+    window.AIFSProgress.onChange(function () {
+      var nextCompleted = window.AIFSProgress.totalCompleted();
+      if (nextCompleted === completed) return;
+      completed = nextCompleted;
+      scheduleAutoExport();
+    });
   }
 
   if (document.readyState === 'loading') {

--- a/site/reminder.js
+++ b/site/reminder.js
@@ -1,0 +1,117 @@
+/**
+ * Progress widget: a compact progress popup shown briefly after progress
+ * changes, then auto-dismisses once the save settles. Counts only the user's
+ * own completed lessons (author-side "complete" status is ignored here).
+ */
+(function () {
+  var widget = null;
+  var hideTimer = null;
+
+  function ensureWidget() {
+    if (widget) return widget;
+    widget = document.createElement('div');
+    widget.id = 'progressWidget';
+    widget.className = 'progress-widget';
+    widget.setAttribute('role', 'status');
+    widget.innerHTML =
+      '<span class="progress-widget-save" id="progressWidgetSave"></span>' +
+      '<span class="progress-widget-text" id="progressWidgetText">0 / 0</span>' +
+      '<div class="progress-widget-bar"><div class="progress-widget-fill" id="progressWidgetFill"></div></div>' +
+      '<span class="progress-widget-pct" id="progressWidgetPct">0%</span>';
+    document.body.appendChild(widget);
+    return widget;
+  }
+
+  function computeTotals() {
+    if (!window.AIFSProgress) return { done: 0, total: 0, pct: 0 };
+    var total = 0;
+    var done = 0;
+    if (typeof PHASES !== 'undefined' && PHASES && PHASES.length) {
+      for (var i = 0; i < PHASES.length; i++) {
+        var lessons = PHASES[i].lessons || [];
+        total += lessons.length;
+        for (var j = 0; j < lessons.length; j++) {
+          if (lessons[j].url) {
+            var lp = window.AIFSProgress.extractPath(lessons[j].url);
+            if (lp && window.AIFSProgress.isLessonComplete(lp)) done++;
+          }
+        }
+      }
+    }
+    var pct = total > 0 ? Math.round((done / total) * 100) : 0;
+    return { done: done, total: total, pct: pct };
+  }
+
+  function setSaveState(state) {
+    var el = document.getElementById('progressWidgetSave');
+    if (!el) return;
+    if (state === 'saving') {
+      el.textContent = '正在保存…';
+      el.className = 'progress-widget-save saving';
+    } else if (state === 'saved') {
+      el.textContent = '已自动保存';
+      el.className = 'progress-widget-save saved';
+    } else {
+      el.textContent = '';
+      el.className = 'progress-widget-save';
+    }
+  }
+
+  function render() {
+    var t = computeTotals();
+    ensureWidget();
+    var fill = document.getElementById('progressWidgetFill');
+    var text = document.getElementById('progressWidgetText');
+    var pctEl = document.getElementById('progressWidgetPct');
+    if (fill) fill.style.width = t.pct + '%';
+    if (text) text.textContent = t.done + ' / ' + t.total;
+    if (pctEl) pctEl.textContent = t.pct + '%';
+  }
+
+  function show() {
+    render();
+    ensureWidget().classList.add('show');
+    if (hideTimer) clearTimeout(hideTimer);
+  }
+
+  function scheduleHide(delay) {
+    if (hideTimer) clearTimeout(hideTimer);
+    hideTimer = setTimeout(function () {
+      var el = document.getElementById('progressWidget');
+      if (el) el.classList.remove('show');
+    }, delay);
+  }
+
+  // Auto-export: silently overwrite the stored save file a moment after
+  // progress changes. Only runs when a file handle with write access already
+  // exists -- never pops a picker. Debounced so bursts of changes write once.
+  var autoExportTimer = null;
+  function scheduleAutoExport() {
+    if (!window.AIFSProgress || !window.AIFSProgress.exportJSON) return;
+    if (autoExportTimer) clearTimeout(autoExportTimer);
+    show();
+    setSaveState('saving');
+    autoExportTimer = setTimeout(function () {
+      autoExportTimer = null;
+      Promise.resolve(window.AIFSProgress.exportJSON(true)).then(function (ok) {
+        setSaveState(ok ? 'saved' : 'idle');
+        // hold the "saved" state briefly, then fade out
+        scheduleHide(ok ? 1800 : 600);
+      }).catch(function () {
+        setSaveState('idle');
+        scheduleHide(600);
+      });
+    }, 2000);
+  }
+
+  function init() {
+    if (!window.AIFSProgress) return;
+    window.AIFSProgress.onChange(scheduleAutoExport);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/site/style.css
+++ b/site/style.css
@@ -569,7 +569,7 @@ p.dropcap::first-letter {
   color: var(--ink-mute);
 }
 
-.modal-reset {
+.modal-reset, .modal-export, .modal-import {
   background: transparent;
   border: 1px solid var(--rule-soft);
   color: var(--ink-mute);
@@ -1390,3 +1390,121 @@ body[data-palette-open] {
     display: none;
   }
 }
+
+/* Global progress export/import actions (stat block) */
+.stat-block-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.stat-block-note {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+  margin-right: auto;
+}
+
+.stat-block-btn {
+  background: transparent;
+  border: 1px solid var(--rule-soft);
+  color: var(--ink-mute);
+  padding: 6px 12px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.stat-block-btn:hover {
+  color: var(--blueprint);
+  border-color: var(--blueprint);
+}
+/* Progress widget: brief popup with slick entrance/exit animation */
+
+/* shared base */
+.progress-widget {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 1000;
+  font-size: 0.74rem;
+  color: var(--ink);
+  opacity: 0;
+  transform: translateY(14px) scale(0.96);
+  pointer-events: none;
+  transition: opacity 0.35s cubic-bezier(0.22, 1, 0.36, 1),
+              transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.progress-widget.show {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+.progress-widget-text,
+.progress-widget-pct {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--ink-soft);
+  white-space: nowrap;
+}
+.progress-widget-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--blueprint), var(--blueprint-tint-strong, rgba(53, 83, 255, 0.6)));
+  background-size: 200% 100%;
+  animation: pw-shimmer 2s linear infinite;
+  transition: width 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+@keyframes pw-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.progress-widget-save {
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+  min-width: 56px;
+  transition: color 0.2s;
+}
+.progress-widget-save.saving { color: var(--blueprint); }
+.progress-widget-save.saving::after {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-left: 6px;
+  border: 1.5px solid var(--blueprint);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: pw-spin 0.7s linear infinite;
+  vertical-align: -1px;
+}
+.progress-widget-save.saved { color: #2e9c5e; animation: pw-pop 0.4s ease; }
+@keyframes pw-spin { to { transform: rotate(360deg); } }
+@keyframes pw-pop { 0% { transform: scale(1); } 45% { transform: scale(1.25); } 100% { transform: scale(1); } }
+
+.progress-widget {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px;
+  background: var(--bg, #fafaf5);
+  border: 1px solid var(--rule-soft);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+}
+.progress-widget .progress-widget-bar {
+  width: 110px;
+  height: 5px;
+  background: var(--rule-soft);
+  border-radius: 3px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+


### PR DESCRIPTION
新增纯前端的学习进度跨设备同步功能，零后端、零账号、零密钥。

功能：
- progress.js: 新增 exportJSON/importJSON，支持 File System Access API 记忆保存位置，后续自动覆写；新增 mergeStates 按时间戳逐课合并， 避免多设备进度互相覆盖
- reminder.js: 进度条浮窗，完成课程后展示进度与自动保存状态， 支持 debounced 自动静默导出（需先手动导出选好位置）
- app.js: 首页与阶段弹窗加导出/导入按钮；首页按钮强制弹文件框
- index.html/lesson.html: 加载 reminder.js，缓存版本号 bump
- style.css: 浮窗动效（缩放+渐隐+shimmer 流光）

设计原则：
- 纯前端，不改变项目零后端性质
- 数据归用户自己（JSON 文件存用户自选位置）
- 进度统计只算用户学习进度，不混入作者制作进度
- 不支持 File System Access API 的浏览器回退到普通下载

<!-- 感谢你的贡献。填写适用的部分，删掉用不上的。 -->

## 这个 PR 做了什么

<!-- 一句话概括。 -->

## 改动类型

- [ ] 新课程
- [ ] 修复现有课程
- [ ] 翻译
- [ ] 新产出（提示词、技能、智能体、MCP 服务器）
- [x] 文档 / 网站 / 工具链

## 检查清单

- [ ] 按列出的依赖运行，代码无报错
- [ ] 代码文件里没有注释（解释写在文档里，代码本身自解释）
- [ ] 先从零实现，再用框架演示（针对新课程）
- [ ] 课程目录符合 `LESSON_TEMPLATE.md` 的结构
- [ ] ROADMAP.md 中该课程那一行是 markdown 链接（`[Name](phases/...)`），而不是纯文本
- [ ] 每个提交只包含一节课（每课原子化提交规则）
- [ ] 已在本地测试 / 代码输出与 `docs/zh.md` 所述一致

## 阶段 / 课程

<!-- 例如 Phase 5 · 03-tokenizers -->

## 给评审者的说明

<!-- 任何意外之处、对模板的偏离、待讨论的问题。 -->
