### PR TITLE
fix(vercel): 让根路径内容协商优先于静态文件

### DIFF
--- a/scripts/test_seo_routes.js
+++ b/scripts/test_seo_routes.js
@@ -477,13 +477,16 @@ test('certification route fails closed and reloads injected fixture assets', fun
   assert.equal(loadCount, 2);
 });
 
-test('deployment routes extensionless pages through handlers and redirects legacy HTML URLs', function () {
+test('deployment routes the root and extensionless pages through handlers without intercepting legacy HTML', function () {
   const repoRoot = path.join(__dirname, '..');
   const config = JSON.parse(fs.readFileSync(path.join(repoRoot, 'vercel.json'), 'utf8'));
   const rewrites = new Map(config.rewrites.map(function (rule) { return [rule.source, rule.destination]; }));
   const routes = new Map((config.routes || []).map(function (rule) { return [rule.src, rule]; }));
   assert.equal(rewrites.get('/lesson'), '/api/lesson');
   assert.equal(rewrites.get('/certification'), '/api/certification');
+  assert.equal(rewrites.has('/'), false);
+  assert.equal(routes.get('/').dest, '/api/markdown?path=/');
+  assert.deepEqual(routes.get('/').methods, ['GET', 'HEAD']);
   assert.equal(routes.has('/lesson\\.html'), false);
   assert.equal(routes.has('/certification\\.html'), false);
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,12 @@
   "outputDirectory": "site",
   "framework": null,
   "installCommand": "echo skip",
+  "routes": [
+    { "src": "/", "methods": ["GET", "HEAD"], "dest": "/api/markdown?path=/" }
+  ],
   "rewrites": [
     { "source": "/lesson", "destination": "/api/lesson" },
     { "source": "/certification", "destination": "/api/certification" },
-    { "source": "/", "has": [{ "type": "header", "key": "accept", "value": ".*" }], "destination": "/api/markdown?path=/" },
     { "source": "/about", "has": [{ "type": "header", "key": "accept", "value": ".*" }], "destination": "/api/markdown?path=/about" },
     { "source": "/catalog", "has": [{ "type": "header", "key": "accept", "value": ".*" }], "destination": "/api/markdown?path=/catalog" },
     { "source": "/glossary", "has": [{ "type": "header", "key": "accept", "value": ".*" }], "destination": "/api/markdown?path=/glossary" },


### PR DESCRIPTION
## 概要

- 用高优先级 Vercel route 将根路径 `/` 交给内容协商 handler
- 浏览器请求继续返回完整 HTML；`Accept: text/markdown` 返回 agent 可读 Markdown
- 保留 `lesson.html` / `certification.html` 静态兼容入口，不扩大 route 拦截范围

## 原因

生产验收发现根路径存在真实 `index.html` 时，conditional rewrite 会被 Vercel filesystem 优先级绕过；其他无实体文件的协商路径不受影响。

## 验证

- `node site/build.js`
- `node scripts/test_seo_routes.js`（24/24）
- `node scripts/test_agent_negotiation.js`（5/5）
- Vercel production build 配置检查
