### PR TITLE
fix(site): 修复生产浏览器运行时回归

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -20,7 +20,6 @@
     initCopyButton();
     initMastheadFigure();
     initFadeObserver();
-    initScrollExplode();
     bindProgressActions('statExport', 'statImport', 'statImportFile');
   });
 

--- a/site/index.html
+++ b/site/index.html
@@ -2288,7 +2288,7 @@
   <script src="reminder.js?v=20260709a"></script>
   <script src="header.js?v=20260831b" defer></script>
   <script src="cmdpalette.js?v=20260831a" defer></script>
-  <script src="app.js?v=20260831a"></script>
+  <script src="app.js?v=20260831b"></script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js"></script>
 </body>
 </html>

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -2725,6 +2725,9 @@
       var flatLessons = [];
       var lessonQuizPromise = null;
       var ACTIVE_REF = window.__AIFS_REF || 'main';
+      var SOURCE_CONFIG = window.__AIFS_SOURCE || {};
+      var SOURCE_OWNER = /^[A-Za-z0-9-]+$/.test(SOURCE_CONFIG.owner || '') ? SOURCE_CONFIG.owner : 'fancyboi999';
+      var SOURCE_REPO = /^[A-Za-z0-9_.-]+$/.test(SOURCE_CONFIG.repo || '') ? SOURCE_CONFIG.repo : 'ai-engineering-from-scratch-zh';
       var REPO_TREE = 'https://github.com/fancyboi999/ai-engineering-from-scratch-zh/tree/' + encodeURIComponent(ACTIVE_REF) + '/';
       var certificationTrack = null;
       var certificationOriginTrack = null;
@@ -3496,15 +3499,6 @@
         // canonical 指向预渲染静态页（SEO 主体）；旧 ?path= URL 仅作兼容入口
         var url = ORIGIN + lessonHref(path);
         var contextTrack = certificationContextTrack();
-        if (certificationLesson) {
-          if (originatingTrackId && certificationOriginTrack) {
-            url += '&fromTrack=' + encodeURIComponent(certificationOriginTrack.id);
-          } else if (certificationMode) {
-            url += '&track=' + encodeURIComponent(certificationTrack.id);
-          } else if (requestedTrackId && certificationOriginTrack) {
-            url += '&track=' + encodeURIComponent(certificationOriginTrack.id);
-          }
-        }
         var desc = lessonDescription(md);
         var courseName = certificationLesson
           ? (contextTrack && (contextTrack.credential || contextTrack.title || contextTrack.shortName) || 'Claude 认证备考')

--- a/site/test_build_artifacts.js
+++ b/site/test_build_artifacts.js
@@ -459,6 +459,7 @@ function writeMarkdown(file, { name, description, version }) {
 
 test('shared site asset families use the expected cache keys on every page', () => {
   const release = '20260831a';
+  const appRelease = '20260831b';
   const styleRelease = '20260831a';
   const navigationRelease = '20260831b';
   const narrationRelease = '20260831a';
@@ -488,7 +489,7 @@ test('shared site asset families use the expected cache keys on every page', () 
     assert.equal(versionFor(source, 'header.js'), navigationRelease, `${page} has stale header.js`);
   }
 
-  assert.equal(versionFor(sourceFor('index.html'), 'app.js'), release);
+  assert.equal(versionFor(sourceFor('index.html'), 'app.js'), appRelease);
   assert.equal(versionFor(sourceFor('prereqs.html'), 'roadmap.css'), release);
   assert.equal(versionFor(sourceFor('prereqs.html'), 'roadmap.js'), release);
   assert.match(
@@ -1534,6 +1535,7 @@ test('website motion contracts keep interaction state stable and compositor-frie
   assert.doesNotMatch(homepageStatBar[0], /transition:\s*width/);
   assert.match(appSource, /barFill\.style\.transform = 'scaleX\('/);
   assert.doesNotMatch(appSource, /barFill\.style\.width\s*=/);
+  assert.doesNotMatch(appSource, /initScrollExplode\s*\(/);
 
   const agentLoop = agentSource.match(/function agentLoop\(host\) \{[\s\S]*?\n  \}\n\n  \/\/ .* react-trace/);
   assert.ok(agentLoop, 'persistent Agent Loop renderer is missing');
@@ -1664,6 +1666,9 @@ test('lesson reader keeps learning-path context and renders a copyable full-dept
   assert.match(lessonHtml, /feedbackTarget\.scrollIntoView/);
   assert.match(lessonHtml, /feedbackTarget\.focus\(\)/);
   assert.match(lessonHtml, /var nextLocked = learningPathMode && learningPathEntryLocked\(next\)/);
+  assert.match(lessonHtml, /var SOURCE_OWNER = [^;]+\? SOURCE_CONFIG\.owner : 'fancyboi999'/);
+  assert.match(lessonHtml, /var SOURCE_REPO = [^;]+\? SOURCE_CONFIG\.repo : 'ai-engineering-from-scratch-zh'/);
+  assert.doesNotMatch(lessonHtml, /url \+= '&(?:fromTrack|track)='/);
   assert.match(
     lessonHtml,
     /data-learning-path-gate-label>'\s*\+\s*\(nextLocked\s*\?\s*'尚未解锁'\s*:\s*'下一节 &rarr;'\)/


### PR DESCRIPTION
## 概要

- 删除首页对不存在 `initScrollExplode()` 的调用
- 为课程目录请求补齐生成仓库身份的 `SOURCE_OWNER` / `SOURCE_REPO`
- 保持认证课程 canonical 无 `track` / `fromTrack` 导航上下文
- 更新首页脚本 cache key

## 原因

production Chromium E2E 发现首页和预渲染课程页存在未捕获 `ReferenceError`，导致课程 outputs / figures 未挂载；认证页 hydration 还会覆盖 SSR canonical。

## 验证

- `node site/build.js`
- `node site/test_build_artifacts.js`（43/43）
- `node scripts/test_seo_routes.js`（24/24）
- production E2E 复现路径已加入源码回归断言
