### PR TITLE
fix(site): 刷新 favicon 缓存键

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="robots" content="noindex"><title>404 · AI Engineering from Scratch 中文版</title><link rel="icon" href="/favicon.ico" sizes="32x32"><link rel="icon" href="/favicon.svg" type="image/svg+xml"><link rel="stylesheet" href="style.css?v=20260831a"></head>
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="robots" content="noindex"><title>404 · AI Engineering from Scratch 中文版</title><link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32"><link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml"><link rel="stylesheet" href="style.css?v=20260831a"></head>
 <body><main class="container" style="max-width:760px;padding-top:18vh"><p class="about-eyebrow">404 · AI Engineering from Scratch</p><h1>页面不存在</h1><pre style="white-space:pre-wrap;line-height:1.7"># AI Engineering from Scratch 中文版
 
 这个路径不存在。

--- a/site/about.html
+++ b/site/about.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>关于 · AI Engineering from Scratch 简体中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="本站是 AI Engineering from Scratch 的简体中文翻译版：一套免费、开源、MIT 许可的课程，把每个核心 AI 算法都从零手写一遍。">
   <link rel="canonical" href="https://aieng-zh.cn/about.html">
   <meta property="og:title" content="关于 · AI Engineering from Scratch 简体中文版">

--- a/site/assessment.html
+++ b/site/assessment.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>认证练习测验 - AI Engineering from Scratch 简体中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="限时原创认证练习；按知识域提供反馈，进度只保存在当前浏览器。">
   <link rel="canonical" href="https://aieng-zh.cn/assessment.html">
   <meta name="robots" content="noindex,follow">

--- a/site/catalog.html
+++ b/site/catalog.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>课程表 - AI Engineering from Scratch</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="523 节 AI 工程课程的完整目录。搜索、筛选、排序全部 20 个阶段的每一节课。">
   <meta property="og:title" content="课程表 · AI Engineering from Scratch">
   <meta property="og:description" content="搜索并筛选 20 个阶段的 523 节课程，覆盖 Python、TypeScript、Rust 与 Julia。">

--- a/site/certification.html
+++ b/site/certification.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <!-- AIFS:CERTIFICATION-SEO:START -->
   <title>Claude 认证路线 - AI Engineering from Scratch 简体中文版</title>
   <meta name="description" content="免费、独立的认证学习路线，包含课程、知识域覆盖、诊断和原创练习。">

--- a/site/certifications.html
+++ b/site/certifications.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Claude 认证备考 - AI Engineering from Scratch 简体中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="免费、独立、开源的 AI 工程认证备考路线。">
   <link rel="canonical" href="https://aieng-zh.cn/certifications.html">
   <meta property="og:title" content="Claude 认证备考 · AI Engineering from Scratch 简体中文版">

--- a/site/contact.html
+++ b/site/contact.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>联系我们 · AI Engineering from Scratch 中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="通过公开项目渠道联系 AI Engineering from Scratch 中文版的维护者和贡献者。">
   <link rel="canonical" href="https://aieng-zh.cn/contact.html"><link rel="stylesheet" href="style.css?v=20260831a">
   <style>

--- a/site/developer.html
+++ b/site/developer.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>开发者资源 · AI Engineering from Scratch 中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="AI Engineering from Scratch 中文版的机器可读资源、公开 URL、OpenAPI 描述、站点地图和 agent 集成说明。">
   <link rel="canonical" href="https://aieng-zh.cn/developer.html">
   <link rel="stylesheet" href="style.css?v=20260831a">

--- a/site/glossary.html
+++ b/site/glossary.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI 工程术语表 - AI Engineering from Scratch 简体中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="实用 AI 工程术语表，提供准确的定义、示例、辨析、相关术语和课程链接。">
   <link rel="canonical" href="https://aieng-zh.cn/glossary.html">
   <meta property="og:title" content="AI 工程术语表 · AI Engineering from Scratch 简体中文版">

--- a/site/index.html
+++ b/site/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Engineering from Scratch · 简体中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="523 节课，20 个阶段。亲手构建数学、模型、训练器、分词器和 agent 循环——一次到位，全手写。">
   <meta property="og:title" content="AI Engineering from Scratch · 简体中文版">
   <meta property="og:description" content="523 节课，20 个阶段。在引入任何框架之前，亲手写出反向传播、分词器、注意力机制和 agent 循环。Python、TypeScript、Rust、Julia。">

--- a/site/learning-paths.html
+++ b/site/learning-paths.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI 工程学习路径 - AI Engineering from Scratch 简体中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="探索四条 AI 工程核心学习路径和六条职业路线；每条都连接到可实践的课程。">
   <link rel="canonical" href="https://aieng-zh.cn/learning-paths.html">
   <meta property="og:title" content="AI 工程学习路径 · AI Engineering from Scratch 简体中文版">

--- a/site/lesson.html
+++ b/site/lesson.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <!-- AIFS:LESSON-SEO:START -->
   <title>课程 - AI Engineering from Scratch</title>
   <meta name="description" content="AI Engineering from Scratch 课程中的一节。523 节课、20 个阶段、四种语言，每个算法都从最原始的数学手写出来。">

--- a/site/prereqs.html
+++ b/site/prereqs.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>学习路线图 - AI Engineering from Scratch 简体中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="覆盖 20 个相连阶段、523 节 AI 工程课程的交互式学习路线图。追踪前置依赖、查看每个阶段解锁的内容，并从本地进度继续学习。">
   <link rel="canonical" href="https://aieng-zh.cn/prereqs.html">
   <meta property="og:title" content="路线图 · AI Engineering from Scratch 简体中文版">

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>隐私 · AI Engineering from Scratch 中文版</title>
-  <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico?v=20260831a" sizes="32x32">
+  <link rel="icon" href="/favicon.svg?v=20260831a" type="image/svg+xml">
   <meta name="description" content="AI Engineering from Scratch 中文课程网站的隐私说明。">
   <link rel="canonical" href="https://aieng-zh.cn/privacy.html"><link rel="stylesheet" href="style.css?v=20260831a">
   <style>

--- a/site/test_build_artifacts.js
+++ b/site/test_build_artifacts.js
@@ -499,6 +499,7 @@ test('shared site asset families use the expected cache keys on every page', () 
 });
 
 test('every public HTML page shares the real favicon assets', () => {
+  const faviconRelease = '20260831a';
   const pages = fs.readdirSync(__dirname)
     .filter(name => name.endsWith('.html') && !/^google[a-z0-9]+\.html$/i.test(name))
     .sort();
@@ -514,12 +515,12 @@ test('every public HTML page shares the real favicon assets', () => {
   for (const page of pages) {
     const source = fs.readFileSync(path.join(__dirname, page), 'utf8');
     assert.equal(
-      (source.match(/<link rel="icon" href="\/favicon\.ico" sizes="32x32">/g) || []).length,
+      (source.match(new RegExp(`<link rel="icon" href="/favicon\\.ico\\?v=${faviconRelease}" sizes="32x32">`, 'g')) || []).length,
       1,
       `${page} must reference /favicon.ico exactly once`
     );
     assert.equal(
-      (source.match(/<link rel="icon" href="\/favicon\.svg" type="image\/svg\+xml">/g) || []).length,
+      (source.match(new RegExp(`<link rel="icon" href="/favicon\\.svg\\?v=${faviconRelease}" type="image/svg\\+xml">`, 'g')) || []).length,
       1,
       `${page} must reference /favicon.svg exactly once`
     );


### PR DESCRIPTION
## 概要

- 为统一 favicon 引用增加 `v=20260831a` cache key
- 保留无参数 `/favicon.ico` 作为浏览器默认回退和爬虫入口
- 避免已经缓存部署前 404 的浏览器继续复用负缓存

## 验证

- `node site/test_build_artifacts.js`（44/44）
- 源站 `/favicon.ico?probe=<timestamp>`：200、`image/vnd.microsoft.icon`、4414 bytes
- `/favicon.svg`：200、`image/svg+xml`
